### PR TITLE
OneOf operator should be case insensitive

### DIFF
--- a/src/rule_evaluator.spec.ts
+++ b/src/rule_evaluator.spec.ts
@@ -117,6 +117,33 @@ describe('matchesAnyRule', () => {
     expect(matchesAnyRule({ userId: 'user15' }, [notOneOfRule])).toEqual(true);
   });
 
+  it('does case insensitive matching with oneOf operator', () => {
+    const oneOfRule: Rule = {
+      conditions: [
+        {
+          operator: OperatorType.ONE_OF,
+          value: ['CA', 'US'],
+          attribute: 'country',
+        },
+      ],
+    };
+    expect(matchesAnyRule({ country: 'us' }, [oneOfRule])).toEqual(true);
+    expect(matchesAnyRule({ country: 'cA' }, [oneOfRule])).toEqual(true);
+  });
+
+  it('does case insensitive matching with notOneOf operator', () => {
+    const notOneOf: Rule = {
+      conditions: [
+        {
+          operator: OperatorType.NOT_ONE_OF,
+          value: ['1.0.BB', '1Ab'],
+          attribute: 'deviceType',
+        },
+      ],
+    };
+    expect(matchesAnyRule({ deviceType: '1ab' }, [notOneOf])).toEqual(false);
+  });
+
   it('handles oneOf rule with number', () => {
     const oneOfRule: Rule = {
       conditions: [

--- a/src/rule_evaluator.ts
+++ b/src/rule_evaluator.ts
@@ -46,11 +46,15 @@ function evaluateCondition(subjectAttributes: Record<string, any>, condition: Co
 }
 
 function isOneOf(attributeValue: any, conditionValue: string[]) {
-  return conditionValue.includes(attributeValue.toString());
+  return getMatchingStringValues(attributeValue.toString(), conditionValue).length > 0;
 }
 
 function isNotOneOf(attributeValue: any, conditionValue: string[]) {
-  return !conditionValue.includes(attributeValue.toString());
+  return getMatchingStringValues(attributeValue.toString(), conditionValue).length === 0;
+}
+
+function getMatchingStringValues(attributeValue: string, conditionValues: string[]): string[] {
+  return conditionValues.filter((value) => value.toLowerCase() === attributeValue.toLowerCase());
 }
 
 function compareNumber(


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes Eppo-exp/eppo#4146

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

If I have a rule such as "country" is one of ["US", "CA"], then lowercase inputs (e.g. "country: 'us'") should still match.

Another scenario is with booleans: a rule such as `"enabled" is one of ["TRUE"]` should match the input `true` (boolean)
