### PR TITLE
Revert Sticky Sessions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [

--- a/src/eppo-client.spec.ts
+++ b/src/eppo-client.spec.ts
@@ -168,12 +168,6 @@ describe('EppoClient E2E test', () => {
     );
   });
 
-  it('uses the same assignment during the session, even if it changes after local storage update', async () => {
-    expect(getInstance().getAssignment(sessionOverrideSubject, preloadedConfigExperiment)).toEqual(
-      'preloaded-config-variation',
-    );
-  });
-
   it('returns subject from overrides when enabled is true', () => {
     const experiment = 'experiment_5';
     window.localStorage.setItem(

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,11 @@ export interface IClientConfig {
    * Pass a logging implementation to send variation assignments to your data warehouse.
    */
   assignmentLogger: IAssignmentLogger;
+
+  /**
+   * If enabled, the SDK getAssignment function will return the same assignment for the lifetime of the browser session.
+   */
+  stickySessionsEnabled?: boolean;
 }
 
 export { IAssignmentLogger, IAssignmentEvent } from './assignment-logger';
@@ -57,7 +62,10 @@ export async function init(config: IClientConfig): Promise<IEppoClient> {
   });
   EppoClient.instance.setLogger(config.assignmentLogger);
   const configurationRequestor = new ExperimentConfigurationRequestor(localStorage, httpClient);
-  if (sessionStorage.get(SESSION_ASSIGNMENT_CONFIG_LOADED) !== 'true') {
+  if (
+    !config.stickySessionsEnabled || // always do request on initialize if sticky sessions disabled
+    sessionStorage.get(SESSION_ASSIGNMENT_CONFIG_LOADED) !== 'true'
+  ) {
     await configurationRequestor.fetchAndStoreConfigurations();
     sessionStorage.set(SESSION_ASSIGNMENT_CONFIG_LOADED, 'true');
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,11 +30,6 @@ export interface IClientConfig {
    * Pass a logging implementation to send variation assignments to your data warehouse.
    */
   assignmentLogger: IAssignmentLogger;
-
-  /**
-   * If enabled, the SDK getAssignment function will return the same assignment for the lifetime of the browser session.
-   */
-  stickySessionsEnabled?: boolean;
 }
 
 export { IAssignmentLogger, IAssignmentEvent } from './assignment-logger';
@@ -62,10 +57,7 @@ export async function init(config: IClientConfig): Promise<IEppoClient> {
   });
   EppoClient.instance.setLogger(config.assignmentLogger);
   const configurationRequestor = new ExperimentConfigurationRequestor(localStorage, httpClient);
-  if (
-    !config.stickySessionsEnabled || // always do request on initialize if sticky sessions disabled
-    sessionStorage.get(SESSION_ASSIGNMENT_CONFIG_LOADED) !== 'true'
-  ) {
+  if (sessionStorage.get(SESSION_ASSIGNMENT_CONFIG_LOADED) !== 'true') {
     await configurationRequestor.fetchAndStoreConfigurations();
     sessionStorage.set(SESSION_ASSIGNMENT_CONFIG_LOADED, 'true');
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,10 +57,8 @@ export async function init(config: IClientConfig): Promise<IEppoClient> {
   });
   EppoClient.instance.setLogger(config.assignmentLogger);
   const configurationRequestor = new ExperimentConfigurationRequestor(localStorage, httpClient);
-  if (sessionStorage.get(SESSION_ASSIGNMENT_CONFIG_LOADED) !== 'true') {
-    await configurationRequestor.fetchAndStoreConfigurations();
-    sessionStorage.set(SESSION_ASSIGNMENT_CONFIG_LOADED, 'true');
-  }
+  await configurationRequestor.fetchAndStoreConfigurations();
+  sessionStorage.set(SESSION_ASSIGNMENT_CONFIG_LOADED, 'true');
   return EppoClient.instance;
 }
 


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

https://www.notion.so/eppo/Null-assignments-with-JS-Client-SDK-4263f4bca87646e5911c2d6be12b80fd

## Description
[//]: # (Describe your changes in detail)

Disabled sticky sessions for the reasons described in the above notion doc. It can be confusing because, if getAssignment is called before initialization, null is returned for the duration of the session.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

- Refreshing the page after the cache TTL expires causes the new variation to load
- Only one request occurs per cache TTL period (10 minutes, or 3 minutes with the updated TTL)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
