### PR TITLE
GitHub workflow to publish to NPM

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish to NPM
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 12
+      - run: npm install
+      - run: npm test
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          access: public

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ This SDK is for client-side JS applications that run in a web browser. For serve
 
 ## Getting Started
 
-Refer to our [SDK documentation](https://docs.geteppo.com/feature-flagging/randomization-sdk) for how to install and use the SDK.
+Refer to our [SDK documentation](https://docs.geteppo.com/prerequisites/feature-flagging/randomization-sdk/client-sdks/javascript) for how to install and use the SDK.


### PR DESCRIPTION
## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Currently the SDK release process is manual;requires running `npm publish` from terminal.

## Description
Added a GitHub workflow to publish to NPM whenever a new GitHub release is created. It only publishes if the version is different than what's currently on NPM. Used [this github action](https://github.com/marketplace/actions/npm-publish)

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
