### PR TITLE
Reduce update latency by using new config endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [

--- a/src/client/eppo-client.spec.ts
+++ b/src/client/eppo-client.spec.ts
@@ -26,7 +26,7 @@ describe('EppoClient E2E test', () => {
     window.localStorage.clear();
     window.sessionStorage.clear();
     mock.setup();
-    mock.get(/randomized_assignment\/v2\/config*/, (_req, res) => {
+    mock.get(/randomized_assignment\/v3\/config*/, (_req, res) => {
       const rac = readMockRacResponse();
       return res.status(200).body(JSON.stringify(rac));
     });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 export const REQUEST_TIMEOUT_MILLIS = 5000;
-export const BASE_URL = 'https://eppo.cloud/api';
+export const BASE_URL = 'https://fscdn.eppo.cloud/api';
 export const SESSION_ASSIGNMENT_CONFIG_LOADED = 'eppo-session-assignment-config-loaded';
 export const NULL_SENTINEL = 'EPPO_NULL';
 // number of logging events that may be queued while waiting for initialization

--- a/src/experiment-configuration-requestor.ts
+++ b/src/experiment-configuration-requestor.ts
@@ -2,7 +2,7 @@ import { IExperimentConfiguration } from './dto/experiment-configuration-dto';
 import HttpClient from './http-client';
 import { EppoLocalStorage } from './local-storage';
 
-const RAC_ENDPOINT = '/randomized_assignment/v2/config';
+const RAC_ENDPOINT = '/randomized_assignment/v3/config';
 
 interface IRandomizedAssignmentConfig {
   flags: Record<string, IExperimentConfiguration>;


### PR DESCRIPTION
## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)
Previously updates to a feature flag's configuration could take multiple minutes to propagate to clients. 

## Description
[//]: # (Describe your changes in detail)
This PR changes the hostname and path of the remote configuration loaded on `init` to use a new version which is updated more quickly than the previous hostname/path. 
