### PR TITLE
bump common version to 1.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@eppo/js-client-sdk-common": "^1.2.1",
+    "@eppo/js-client-sdk-common": "^1.2.2",
     "axios": "^0.27.2",
     "md5": "^2.3.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -289,10 +289,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@eppo/js-client-sdk-common@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-1.2.1.tgz#7161e9e22233b411d70f3977effb91a3b2290b26"
-  integrity sha512-3SGtgyJRNb+RsZdZ+acaD1bNfuiXJxN31OTXbRQO57RUrR6In0nmKdp/3aOiHj/CqDu/QbmdNe2zVjgetihfqw==
+"@eppo/js-client-sdk-common@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-1.2.2.tgz#4662c70e107033ee5e8a76da876bdfc80e7f698e"
+  integrity sha512-0ABH/tD7MrIbSMhrZQs4FDE6VfrdE4gZ1Z1xDZ/EDOmQnaOCABKw2DDmT0DQPGnMAFGBa0NUNuZmS1RHauil1A==
   dependencies:
     axios "^0.27.2"
     md5 "^2.3.0"


### PR DESCRIPTION
## Description
[//]: # (Describe your changes in detail)
Upgrade common lib to [v1.2.2](https://github.com/Eppo-exp/js-client-sdk-common/releases/tag/v1.2.2)