### PR TITLE
Update common to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@eppo/js-client-sdk-common": "^1.3.0",
+    "@eppo/js-client-sdk-common": "^1.3.1",
     "axios": "^0.27.2",
     "md5": "^2.3.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -289,10 +289,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@eppo/js-client-sdk-common@^1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-1.3.0.tgz#abbc926ad31a8d96501ee443077f60138316a59e"
-  integrity sha512-OYbonzTW/uYgFBt6Ac03NEu2JviIiLQainP/wKH9L6GT/cGAxqDWV5+6wkqsk8r0sDRia2FI2a3jFp+1+DcnRA==
+"@eppo/js-client-sdk-common@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-1.3.1.tgz#5688eb6a2bc96339446c12f2576016c9cddd52e3"
+  integrity sha512-hxvGSqr+55ZALMe7wv76gFXuFgOAaApI1EepLGWX80xLb2r1gNke9+IEYQWe8kXLB+EUCaQJ1v4/c3OBqk9vQQ==
   dependencies:
     axios "^0.27.2"
     md5 "^2.3.0"


### PR DESCRIPTION
## Description
[//]: # (Describe your changes in detail)
Update Eppo js-client-sdk-common to version [v1.3.0](https://github.com/Eppo-exp/js-client-sdk-common/releases/tag/v1.3.0) to pull in changes for assignment callbacks. 