### PR TITLE
Update eppo js commons dependency to v1.4.1 to include allocation key in logged event's experiment attribute (FF-858) 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,18 @@ help: Makefile
 
 ## test-data
 testDataDir := test/data/
+tempDir := ${testDataDir}temp/
+gitDataDir := ${tempDir}sdk-test-data/
+branchName := main
+githubRepoLink := https://github.com/Eppo-exp/sdk-test-data.git
 .PHONY: test-data
-test-data:
+test-data: 
 	rm -rf $(testDataDir)
-	mkdir -p $(testDataDir)
-	gsutil cp gs://sdk-test-data/rac-experiments-v2.json $(testDataDir)
-	gsutil cp -r gs://sdk-test-data/assignment-v2 $(testDataDir)
+	mkdir -p $(tempDir)
+	git clone -b ${branchName} --depth 1 --single-branch ${githubRepoLink} ${gitDataDir}
+	cp ${gitDataDir}rac-experiments-v3.json ${testDataDir}
+	cp -r ${gitDataDir}assignment-v2 ${testDataDir}
+	rm -rf ${tempDir}
 
 ## prepare
 .PHONY: prepare

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@eppo/js-client-sdk-common": "^1.3.1",
+    "@eppo/js-client-sdk-common": "^1.4.1",
     "axios": "^0.27.2",
     "md5": "^2.3.0"
   }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -10,10 +10,10 @@ import {
   readMockRacResponse,
 } from '../test/testHelpers';
 
-import { EppoJSClient, init } from './index';
+import { IEppoClient, init } from './index';
 
 describe('EppoJSClient E2E test', () => {
-  let client: EppoJSClient;
+  let client: IEppoClient;
 
   beforeAll(async () => {
     mock.setup();
@@ -69,7 +69,7 @@ describe('EppoJSClient E2E test', () => {
     });
   });
 
-  function getAssignments(subjects: string[], experiment: string): string[] {
+  function getAssignments(subjects: string[], experiment: string): (string | null)[] {
     return subjects.map((subjectKey) => {
       return client.getAssignment(subjectKey, experiment);
     });
@@ -82,7 +82,7 @@ describe('EppoJSClient E2E test', () => {
       subjectAttributes: Record<string, any>;
     }[],
     experiment: string,
-  ): string[] {
+  ): (string | null)[] {
     return subjectsWithAttributes.map((subject) => {
       return client.getAssignment(subject.subjectKey, experiment, subject.subjectAttributes);
     });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 
+import * as td from 'testdouble';
 import mock from 'xhr-mock';
 
 import {
@@ -10,10 +11,62 @@ import {
   readMockRacResponse,
 } from '../test/testHelpers';
 
-import { IEppoClient, init } from './index';
+import { EppoLocalStorage } from './local-storage';
+
+import { EppoJSClient, IAssignmentLogger, IEppoClient, init } from './index';
 
 describe('EppoJSClient E2E test', () => {
-  let client: IEppoClient;
+  let globalClient: IEppoClient;
+
+  const flagKey = 'mock-experiment';
+
+  const mockExperimentConfig = {
+    name: flagKey,
+    enabled: true,
+    subjectShards: 100,
+    overrides: {},
+    typedOverrides: {},
+    rules: [
+      {
+        allocationKey: 'allocation1',
+        conditions: [],
+      },
+    ],
+    allocations: {
+      allocation1: {
+        percentExposure: 1,
+        variations: [
+          {
+            name: 'control',
+            value: 'control',
+            typedValue: 'control',
+            shardRange: {
+              start: 0,
+              end: 34,
+            },
+          },
+          {
+            name: 'variant-1',
+            value: 'variant-1',
+            typedValue: 'variant-1',
+            shardRange: {
+              start: 34,
+              end: 67,
+            },
+          },
+          {
+            name: 'variant-2',
+            value: 'variant-2',
+            typedValue: 'variant-2',
+            shardRange: {
+              start: 67,
+              end: 100,
+            },
+          },
+        ],
+      },
+    },
+  };
 
   beforeAll(async () => {
     mock.setup();
@@ -21,7 +74,7 @@ describe('EppoJSClient E2E test', () => {
       const rac = readMockRacResponse();
       return res.status(200).body(JSON.stringify(rac));
     });
-    client = await init({
+    globalClient = await init({
       apiKey: 'dummy',
       baseUrl: 'http://127.0.0.1:4000',
       assignmentLogger: {
@@ -35,6 +88,116 @@ describe('EppoJSClient E2E test', () => {
 
   afterAll(() => {
     mock.teardown();
+  });
+
+  it('assigns subject from overrides when experiment is enabled', () => {
+    const mockConfigStore = td.object<EppoLocalStorage>();
+    const mockLogger = td.object<IAssignmentLogger>();
+    td.when(mockConfigStore.get(flagKey)).thenReturn({
+      ...mockExperimentConfig,
+      overrides: {
+        '1b50f33aef8f681a13f623963da967ed': 'variant-2',
+      },
+      typedOverrides: {
+        '1b50f33aef8f681a13f623963da967ed': 'variant-2',
+      },
+    });
+    const client = new EppoJSClient(mockConfigStore);
+    client.setLogger(mockLogger);
+    const assignment = client.getAssignment('subject-10', flagKey);
+    expect(assignment).toEqual('variant-2');
+  });
+
+  it('assigns subject from overrides when experiment is not enabled', () => {
+    const mockConfigStore = td.object<EppoLocalStorage>();
+    const mockLogger = td.object<IAssignmentLogger>();
+    td.when(mockConfigStore.get(flagKey)).thenReturn({
+      ...mockExperimentConfig,
+      overrides: {
+        '1b50f33aef8f681a13f623963da967ed': 'variant-2',
+      },
+      typedOverrides: {
+        '1b50f33aef8f681a13f623963da967ed': 'variant-2',
+      },
+    });
+    const client = new EppoJSClient(mockConfigStore);
+    client.setLogger(mockLogger);
+    const assignment = client.getAssignment('subject-10', flagKey);
+    expect(assignment).toEqual('variant-2');
+  });
+
+  it('returns null when experiment config is absent', () => {
+    const mockConfigStore = td.object<EppoLocalStorage>();
+    const mockLogger = td.object<IAssignmentLogger>();
+    td.when(mockConfigStore.get(flagKey)).thenReturn(null);
+    const client = new EppoJSClient(mockConfigStore);
+    client.setLogger(mockLogger);
+    const assignment = client.getAssignment('subject-10', flagKey);
+    expect(assignment).toEqual(null);
+  });
+
+  it('logs variation assignment and experiment key', () => {
+    const mockConfigStore = td.object<EppoLocalStorage>();
+    const mockLogger = td.object<IAssignmentLogger>();
+    td.when(mockConfigStore.get(flagKey)).thenReturn(mockExperimentConfig);
+    const subjectAttributes = { foo: 3 };
+    const client = new EppoJSClient(mockConfigStore);
+    client.setLogger(mockLogger);
+    const assignment = client.getAssignment('subject-10', flagKey, subjectAttributes);
+    expect(assignment).toEqual('control');
+    expect(td.explain(mockLogger.logAssignment).callCount).toEqual(1);
+    expect(td.explain(mockLogger?.logAssignment).calls[0]?.args[0].subject).toEqual('subject-10');
+    expect(td.explain(mockLogger?.logAssignment).calls[0]?.args[0].featureFlag).toEqual(flagKey);
+    expect(td.explain(mockLogger?.logAssignment).calls[0]?.args[0].experiment).toEqual(
+      `${flagKey}-${mockExperimentConfig?.rules[0]?.allocationKey}`,
+    );
+    expect(td.explain(mockLogger?.logAssignment).calls[0]?.args[0].allocation).toEqual(
+      `${mockExperimentConfig?.rules[0]?.allocationKey}`,
+    );
+  });
+
+  it('handles logging exception', () => {
+    const mockConfigStore = td.object<EppoLocalStorage>();
+    const mockLogger = td.object<IAssignmentLogger>();
+    td.when(mockLogger.logAssignment(td.matchers.anything())).thenThrow(new Error('logging error'));
+    td.when(mockConfigStore.get(flagKey)).thenReturn(mockExperimentConfig);
+    const subjectAttributes = { foo: 3 };
+    const client = new EppoJSClient(mockConfigStore);
+    client.setLogger(mockLogger);
+    const assignment = client.getAssignment('subject-10', flagKey, subjectAttributes);
+    expect(assignment).toEqual('control');
+  });
+
+  it('only returns variation if subject matches rules', () => {
+    const mockConfigStore = td.object<EppoLocalStorage>();
+    const mockLogger = td.object<IAssignmentLogger>();
+    td.when(mockConfigStore.get(flagKey)).thenReturn({
+      ...mockExperimentConfig,
+      rules: [
+        {
+          allocationKey: 'allocation1',
+          conditions: [
+            {
+              operator: 'GT',
+              attribute: 'appVersion',
+              value: 10,
+            },
+          ],
+        },
+      ],
+    });
+    const client = new EppoJSClient(mockConfigStore);
+    client.setLogger(mockLogger);
+    let assignment = client.getAssignment('subject-10', flagKey, {
+      appVersion: 9,
+    });
+    expect(assignment).toEqual(null);
+    assignment = client.getAssignment('subject-10', flagKey);
+    expect(assignment).toEqual(null);
+    assignment = client.getAssignment('subject-10', flagKey, {
+      appVersion: 11,
+    });
+    expect(assignment).toEqual('control');
   });
 
   describe('getAssignment', () => {
@@ -71,7 +234,7 @@ describe('EppoJSClient E2E test', () => {
 
   function getAssignments(subjects: string[], experiment: string): (string | null)[] {
     return subjects.map((subjectKey) => {
-      return client.getAssignment(subjectKey, experiment);
+      return globalClient.getAssignment(subjectKey, experiment);
     });
   }
 
@@ -84,7 +247,7 @@ describe('EppoJSClient E2E test', () => {
     experiment: string,
   ): (string | null)[] {
     return subjectsWithAttributes.map((subject) => {
-      return client.getAssignment(subject.subjectKey, experiment, subject.subjectAttributes);
+      return globalClient.getAssignment(subject.subjectKey, experiment, subject.subjectAttributes);
     });
   }
 });

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -1,11 +1,11 @@
 import * as fs from 'fs';
 
-import { IExperimentConfiguration } from '../src/dto/experiment-configuration-dto';
-import { IVariation } from '../src/experiment/variation-dto';
+import { IExperimentConfiguration } from '@eppo/js-client-sdk-common/dist/dto/experiment-configuration-dto';
+import { IVariation } from '@eppo/js-client-sdk-common/dist/dto/variation-dto';
 
 export const TEST_DATA_DIR = './test/data/';
 export const ASSIGNMENT_TEST_DATA_DIR = TEST_DATA_DIR + 'assignment-v2/';
-export const MOCK_RAC_RESPONSE_FILE = 'rac-experiments-v2.json';
+export const MOCK_RAC_RESPONSE_FILE = 'rac-experiments-v3.json';
 
 export interface IAssignmentTestCase {
   experiment: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -289,10 +289,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@eppo/js-client-sdk-common@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-1.3.1.tgz#5688eb6a2bc96339446c12f2576016c9cddd52e3"
-  integrity sha512-hxvGSqr+55ZALMe7wv76gFXuFgOAaApI1EepLGWX80xLb2r1gNke9+IEYQWe8kXLB+EUCaQJ1v4/c3OBqk9vQQ==
+"@eppo/js-client-sdk-common@^1.4.1":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-1.4.1.tgz#b75bb34c9004ea34070be38250532e04d2683e83"
+  integrity sha512-1dPursZSgtJb7ufLbePI1qIryydFTP6Y+EJYiV+I1njhBEdIUjc/E1+Qe3kBDSXoyowrk8VjUZGV4RD4YnPhcA==
   dependencies:
     axios "^0.27.2"
     md5 "^2.3.0"


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: [FF-858](https://linear.app/eppo/issue/FF-858/update-javascript-sdk-with-allocation-key)

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

## Description
[//]: # (Describe your changes in detail)

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
