### PR TITLE
Bump node version to 18.x

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: '18.x'
       - run: yarn install
       - run: yarn test
       - uses: JS-DevTools/npm-publish@v1


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Still failing to publish, with a new error: https://github.com/Eppo-exp/js-client-sdk/actions/runs/6279038634/job/17054001216

```
10s
Run yarn install
yarn install v[1](https://github.com/Eppo-exp/js-client-sdk/actions/runs/6279038634/job/17054001216#step:4:1).22.19
[1/[4](https://github.com/Eppo-exp/js-client-sdk/actions/runs/6279038634/job/17054001216#step:4:5)] Resolving packages...
[2/4] Fetching packages...
error husky@8.0.1: The engine "node" is incompatible with this module. Expected version ">=14". Got "12.22.12"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: Process completed with exit code 1.
```

## Description
[//]: # (Describe your changes in detail)

Bumped to the same version used in lint-test-sdk.yml

https://github.com/Eppo-exp/js-client-sdk/blob/8a3401654453a9bc9acc99697402815d017a779c/.github/workflows/lint-test-sdk.yml#L15

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

🤷 

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
