### PR TITLE
Adds LocalStorageAssignmentCache with persistent implementation between sessions to lower assignment logging; enabled by default (FF-839)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@eppo/js-client-sdk-common": "file:../js-client-sdk-common",
+    "@eppo/js-client-sdk-common": "2.0.0",
     "axios": "^1.6.0",
     "md5": "^2.3.0"
   }

--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@eppo/js-client-sdk-common": "^1.7.0",
-    "axios": "^0.27.2",
+    "@eppo/js-client-sdk-common": "file:../js-client-sdk-common",
+    "axios": "^1.6.0",
     "md5": "^2.3.0"
   }
 }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -283,7 +283,24 @@ describe('EppoJSClient E2E test', () => {
           allocationKey: 'allocation-1',
           variationValue: EppoValue.String('control'),
         }),
-      ).toEqual(true);
+      ).toEqual(true); // this key has been logged
+
+      // change variation
+      cache.setLastLoggedAssignment({
+        subjectKey: 'subject-1',
+        flagKey: 'flag-1',
+        allocationKey: 'allocation-1',
+        variationValue: EppoValue.String('variant'),
+      });
+
+      expect(
+        cache.hasLoggedAssignment({
+          subjectKey: 'subject-1',
+          flagKey: 'flag-1',
+          allocationKey: 'allocation-1',
+          variationValue: EppoValue.String('control'),
+        }),
+      ).toEqual(false); // this key has not been logged
     });
   });
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -15,6 +15,7 @@ import {
 } from '../test/testHelpers';
 
 import { EppoLocalStorage } from './local-storage';
+import { LocalStorageAssignmentCache } from './local-storage-assignment-cache';
 
 import { EppoJSClient, IAssignmentLogger, IEppoClient, init } from './index';
 
@@ -253,6 +254,36 @@ describe('EppoJSClient E2E test', () => {
 
     it('runs expected number of test cases', () => {
       expect(testData.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('LocalStorageAssignmentCache', () => {
+    it('typical behavior', () => {
+      const cache = new LocalStorageAssignmentCache();
+      expect(
+        cache.hasLoggedAssignment({
+          subjectKey: 'subject-1',
+          flagKey: 'flag-1',
+          allocationKey: 'allocation-1',
+          variationValue: EppoValue.String('control'),
+        }),
+      ).toEqual(false);
+
+      cache.setLastLoggedAssignment({
+        subjectKey: 'subject-1',
+        flagKey: 'flag-1',
+        allocationKey: 'allocation-1',
+        variationValue: EppoValue.String('control'),
+      });
+
+      expect(
+        cache.hasLoggedAssignment({
+          subjectKey: 'subject-1',
+          flagKey: 'flag-1',
+          allocationKey: 'allocation-1',
+          variationValue: EppoValue.String('control'),
+        }),
+      ).toEqual(true);
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
 import axios from 'axios';
 
 import { EppoLocalStorage } from './local-storage';
+import { LocalStorageAssignmentCache } from './local-storage-assignment-cache';
 import { sdkName, sdkVersion } from './sdk-data';
 
 /**
@@ -150,9 +151,9 @@ export async function init(config: IClientConfig): Promise<IEppoClient> {
     });
     EppoJSClient.instance.setLogger(config.assignmentLogger);
 
-    // default behavior is to use a non-expiring cache.
+    // default behavior is to use a LocalStorage-based assignment cache.
     // this can be overridden after initialization.
-    EppoJSClient.instance.useNonExpiringAssignmentCache();
+    EppoJSClient.instance.useCustomAssignmentCache(new LocalStorageAssignmentCache());
 
     const configurationRequestor = new ExperimentConfigurationRequestor(localStorage, httpClient);
     await configurationRequestor.fetchAndStoreConfigurations();

--- a/src/local-storage-assignment-cache.ts
+++ b/src/local-storage-assignment-cache.ts
@@ -1,0 +1,51 @@
+import { AssignmentCache } from '@eppo/js-client-sdk-common';
+
+import { hasWindowLocalStorage } from './local-storage';
+
+class LocalStorageAssignmentShim {
+  LOCAL_STORAGE_KEY = 'EPPO_LOCAL_STORAGE_ASSIGNMENT_CACHE';
+
+  public has(key: string): boolean {
+    if (!hasWindowLocalStorage()) {
+      return false;
+    }
+
+    return this.getCache().has(key);
+  }
+
+  public get(key: string): string {
+    if (!hasWindowLocalStorage()) {
+      return null;
+    }
+
+    return this.getCache().get(key);
+  }
+
+  public set(key: string, value: string) {
+    if (!hasWindowLocalStorage()) {
+      return;
+    }
+
+    const cache = this.getCache();
+    cache.set(key, value);
+    this.setCache(cache);
+  }
+
+  private getCache(): Map<string, string> {
+    const cache = window.localStorage.getItem(this.LOCAL_STORAGE_KEY);
+    return cache ? new Map(JSON.parse(cache)) : new Map();
+  }
+
+  private setCache(cache: Map<string, string>) {
+    window.localStorage.setItem(
+      this.LOCAL_STORAGE_KEY,
+      JSON.stringify(Array.from(cache.entries())),
+    );
+  }
+}
+
+export class LocalStorageAssignmentCache extends AssignmentCache<LocalStorageAssignmentShim> {
+  constructor() {
+    super(new LocalStorageAssignmentShim());
+  }
+}

--- a/src/local-storage.ts
+++ b/src/local-storage.ts
@@ -1,6 +1,6 @@
 export class EppoLocalStorage {
   public get<T>(key: string): T {
-    if (this.hasWindowLocalStorage()) {
+    if (hasWindowLocalStorage()) {
       const serializedEntry = window.localStorage.getItem(key);
       if (serializedEntry) {
         return JSON.parse(serializedEntry);
@@ -9,21 +9,21 @@ export class EppoLocalStorage {
     return null;
   }
 
-  // Checks whether local storage is enabled in the browser (the user might have disabled it).
-  private hasWindowLocalStorage(): boolean {
-    try {
-      return typeof window !== 'undefined' && !!window.localStorage;
-    } catch {
-      // Chrome throws an error if local storage is disabled and you try to access it
-      return false;
-    }
-  }
-
   public setEntries<T>(entries: Record<string, T>) {
-    if (this.hasWindowLocalStorage()) {
+    if (hasWindowLocalStorage()) {
       Object.entries(entries).forEach(([key, val]) => {
         window.localStorage.setItem(key, JSON.stringify(val));
       });
     }
+  }
+}
+
+// Checks whether local storage is enabled in the browser (the user might have disabled it).
+export function hasWindowLocalStorage(): boolean {
+  try {
+    return typeof window !== 'undefined' && !!window.localStorage;
+  } catch {
+    // Chrome throws an error if local storage is disabled and you try to access it
+    return false;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -373,12 +373,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@eppo/js-client-sdk-common@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-1.7.0.tgz#13f563af6ae7d030f5be772bcee7a35ca07127c0"
-  integrity sha512-2E8Okt2oRv5cPWhLzLAdoZkOFiDOUCy3pJw47XJWmfjw29AggEYH/OFjeC5/EU+XjGUA3CWBIrhBIHtkGKfqXg==
+"@eppo/js-client-sdk-common@file:../js-client-sdk-common":
+  version "1.8.1"
   dependencies:
-    axios "^0.27.2"
+    axios "^1.6.0"
     lru-cache "^10.0.1"
     md5 "^2.3.0"
 
@@ -1442,13 +1440,14 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^0.27.2:
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
-  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+axios@^1.6.0:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.2.tgz#de67d42c755b571d3e698df1b6504cde9b0ee9f2"
+  integrity sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==
   dependencies:
-    follow-redirects "^1.14.9"
+    follow-redirects "^1.15.0"
     form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 babel-jest@^29.7.0:
   version "29.7.0"
@@ -2358,10 +2357,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
-follow-redirects@^1.14.9:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
-  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+follow-redirects@^1.15.0:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
+  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
 
 form-data@^4.0.0:
   version "4.0.0"
@@ -3979,6 +3978,11 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -373,8 +373,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@eppo/js-client-sdk-common@file:../js-client-sdk-common":
-  version "1.8.1"
+"@eppo/js-client-sdk-common@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-2.0.0.tgz#562006a128fb33653ca8c5e17df7680f7d91d0b4"
+  integrity sha512-yHi4BFb6N7jISPK4y++N9OwjJBQAONSLqqCoCUHAyFSlNmUm+aNc/a+j/HHPsnXYZ1GUBWAZJOIQDNne4svfPg==
   dependencies:
     axios "^1.6.0"
     lru-cache "^10.0.1"


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Downstream related change: https://github.com/Eppo-exp/js-client-sdk-common/pull/33 enables passing an implementation.

The goal is for users of Eppo's SDK in the browser to remove duplicate assignments within and now between sessions.

We are creating a cache based on `LocalStorage` which is a unique API to browsers.

## Description
[//]: # (Describe your changes in detail)

* Use only a single `LocalStorage` key for the entire assignment cache - it is always for a single subject.
* Instantiate the js client with this cache.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

* New integration test.

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
