### PR TITLE
EPD-1930 upgrade @eppo/js-client-sdk-common and axios versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [
@@ -57,8 +57,8 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@eppo/js-client-sdk-common": "^1.7.0",
-    "axios": "^0.27.2",
+    "@eppo/js-client-sdk-common": "^2.0.0",
+    "axios": "^1.6.0",
     "md5": "^2.3.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -152,7 +152,7 @@ export async function init(config: IClientConfig): Promise<IEppoClient> {
 
     // default behavior is to use a non-expiring cache.
     // this can be overridden after initialization.
-    EppoJSClient.instance.useNonExpiringAssignmentCache();
+    EppoJSClient.instance.useNonExpiringInMemoryAssignmentCache();
 
     const configurationRequestor = new ExperimentConfigurationRequestor(localStorage, httpClient);
     await configurationRequestor.fetchAndStoreConfigurations();

--- a/yarn.lock
+++ b/yarn.lock
@@ -373,12 +373,12 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@eppo/js-client-sdk-common@^1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-1.7.0.tgz#13f563af6ae7d030f5be772bcee7a35ca07127c0"
-  integrity sha512-2E8Okt2oRv5cPWhLzLAdoZkOFiDOUCy3pJw47XJWmfjw29AggEYH/OFjeC5/EU+XjGUA3CWBIrhBIHtkGKfqXg==
+"@eppo/js-client-sdk-common@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-2.0.0.tgz#562006a128fb33653ca8c5e17df7680f7d91d0b4"
+  integrity sha512-yHi4BFb6N7jISPK4y++N9OwjJBQAONSLqqCoCUHAyFSlNmUm+aNc/a+j/HHPsnXYZ1GUBWAZJOIQDNne4svfPg==
   dependencies:
-    axios "^0.27.2"
+    axios "^1.6.0"
     lru-cache "^10.0.1"
     md5 "^2.3.0"
 
@@ -1442,13 +1442,14 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^0.27.2:
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
-  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+axios@^1.6.0:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.2.tgz#de67d42c755b571d3e698df1b6504cde9b0ee9f2"
+  integrity sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==
   dependencies:
-    follow-redirects "^1.14.9"
+    follow-redirects "^1.15.0"
     form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
 
 babel-jest@^29.7.0:
   version "29.7.0"
@@ -2358,10 +2359,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.5.tgz#76c8584f4fc843db64702a6bd04ab7a8bd666da3"
   integrity sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==
 
-follow-redirects@^1.14.9:
-  version "1.15.1"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
-  integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
+follow-redirects@^1.15.0:
+  version "1.15.3"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
+  integrity sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==
 
 form-data@^4.0.0:
   version "4.0.0"
@@ -3979,6 +3980,11 @@ prompts@^2.0.1:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 psl@^1.1.33:
   version "1.8.0"


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: EPD-1930

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Vanta shows a security issue:

https://github.com/Eppo-exp/js-client-sdk/security/dependabot/12

## Description
[//]: # (Describe your changes in detail)

- upgrade js-client-sdk-common
- upgrade axios itself
- some fixes for js-client-sdk-common:2.0.0

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

With `yarn why axios`:

```
(base) pavel@Pavels-MacBook-Pro-2 js-client-sdk % yarn why axios
yarn why v1.22.19
[1/4] 🤔  Why do we have the module "axios"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "axios@1.6.2"
info Has been hoisted to "axios"
info Reasons this module exists
   - Specified in "dependencies"
   - Hoisted from "@eppo#js-client-sdk-common#axios"
info Disk size without dependencies: "2.02MB"
info Disk size with unique dependencies: "2.17MB"
info Disk size with transitive dependencies: "2.55MB"
info Number of shared dependencies: 4
✨  Done in 0.15s.
```


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
