### PR TITLE
bump commons to 2.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [
@@ -58,7 +58,7 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@eppo/js-client-sdk-common": "2.2.2",
+    "@eppo/js-client-sdk-common": "2.2.3",
     "md5": "^2.3.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,13 +380,12 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@eppo/js-client-sdk-common@2.2.2":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-2.2.2.tgz#3fe1f0ab2c04584b39e4b67b8c654e87319bf90f"
-  integrity sha512-l6VTWMJuVGiM3uYuYK55VzVMGQ6eXTNnmCP7dnKnTEfDF6MT6Co0mMC0lqrYYW2x/yISlEzF0NMkeK2fDkoMBw==
+"@eppo/js-client-sdk-common@2.2.3":
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-2.2.3.tgz#004cebb02bd132d7e02591513dffc0dbb0436289"
+  integrity sha512-yrqA6F3TbSwUVaqTcAvfX+5rKs49eXSptqJf68jq6ZIoSFWo3onfLmJdOZ4cu3AEG3DrXxvzUmykpmtSimxaHQ==
   dependencies:
     axios "^1.6.0"
-    lru-cache "^10.0.1"
     md5 "^2.3.0"
     pino "^8.19.0"
     semver "^7.5.4"
@@ -3530,11 +3529,6 @@ log-update@^4.0.0:
     cli-cursor "^3.1.0"
     slice-ansi "^4.0.0"
     wrap-ansi "^6.2.0"
-
-lru-cache@^10.0.1:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.2.0.tgz#0bd445ca57363465900f4d1f9bd8db343a4d95c3"
-  integrity sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==
 
 lru-cache@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

* drops `lru-cache` external dependency; allows for an upgrade path for blocked customers

## Description
[//]: # (Describe your changes in detail)

next steps: integrate into eppo app before customer notification

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
