### PR TITLE
bump to commons 3.0.6; add LocalStorageBackedAsyncStore (FF-1980)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {
-    "@eppo/js-client-sdk-common": "3.0.2",
+    "@eppo/js-client-sdk-common": "3.0.6",
     "md5": "^2.3.0"
   }
 }

--- a/src/configuration-factory.ts
+++ b/src/configuration-factory.ts
@@ -1,0 +1,30 @@
+import {
+  Flag,
+  HybridConfigurationStore,
+  IConfigurationStore,
+  MemoryOnlyConfigurationStore,
+  MemoryStore,
+} from '@eppo/js-client-sdk-common';
+
+import { LocalStorageBackedAsyncStore } from './local-storage';
+
+export function configurationStorageFactory(): IConfigurationStore<Flag> {
+  if (hasWindowLocalStorage()) {
+    // fallback to window.localStorage if available
+    return new HybridConfigurationStore(
+      new MemoryStore<Flag>(),
+      new LocalStorageBackedAsyncStore<Flag>(window.localStorage),
+    );
+  }
+
+  return new MemoryOnlyConfigurationStore();
+}
+
+export function hasWindowLocalStorage(): boolean {
+  try {
+    return typeof window !== 'undefined' && !!window.localStorage;
+  } catch {
+    // Chrome throws an error if local storage is disabled and you try to access it
+    return false;
+  }
+}

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -4,7 +4,12 @@
 
 import { createHash } from 'crypto';
 
-import { HttpClient, Flag, VariationType, constants } from '@eppo/js-client-sdk-common';
+import {
+  Flag,
+  VariationType,
+  constants,
+  HybridConfigurationStore,
+} from '@eppo/js-client-sdk-common';
 import * as md5 from 'md5';
 import * as td from 'testdouble';
 import { encode } from 'universal-base64';
@@ -21,9 +26,6 @@ import {
   validateTestAssignments,
 } from '../test/testHelpers';
 
-import { EppoLocalStorage } from './local-storage';
-import { LocalStorageAssignmentCache } from './local-storage-assignment-cache';
-
 import { IAssignmentLogger, IEppoClient, getInstance, init } from './index';
 
 export function md5Hash(input: string): string {
@@ -34,77 +36,76 @@ export function base64Encode(input: string): string {
   return Buffer.from(input).toString('base64');
 }
 
+// Configuration for a single flag within the UFC.
+const apiKey = 'dummy';
+const baseUrl = 'http://127.0.0.1:4000';
+
+const flagKey = 'mock-experiment';
+const obfuscatedFlagKey = md5(flagKey);
+
+const allocationKey = 'traffic-split';
+const obfuscatedAllocationKey = base64Encode(allocationKey);
+
+const mockUfcFlagConfig: Flag = {
+  key: obfuscatedFlagKey,
+  enabled: true,
+  variationType: VariationType.STRING,
+  variations: {
+    [base64Encode('control')]: {
+      key: base64Encode('control'),
+      value: base64Encode('control'),
+    },
+    [base64Encode('variant-1')]: {
+      key: base64Encode('variant-1'),
+      value: base64Encode('variant-1'),
+    },
+    [base64Encode('variant-2')]: {
+      key: base64Encode('variant-2'),
+      value: base64Encode('variant-2'),
+    },
+  },
+  allocations: [
+    {
+      key: obfuscatedAllocationKey,
+      rules: [],
+      splits: [
+        {
+          variationKey: base64Encode('control'),
+          shards: [
+            {
+              salt: base64Encode('some-salt'),
+              ranges: [{ start: 0, end: 3400 }],
+            },
+          ],
+        },
+        {
+          variationKey: base64Encode('variant-1'),
+          shards: [
+            {
+              salt: base64Encode('some-salt'),
+              ranges: [{ start: 3400, end: 6700 }],
+            },
+          ],
+        },
+        {
+          variationKey: base64Encode('variant-2'),
+          shards: [
+            {
+              salt: base64Encode('some-salt'),
+              ranges: [{ start: 6700, end: 10000 }],
+            },
+          ],
+        },
+      ],
+      doLog: true,
+    },
+  ],
+  totalShards: 10000,
+};
+
 describe('EppoJSClient E2E test', () => {
   let globalClient: IEppoClient;
   let mockLogger: IAssignmentLogger;
-  let returnUfc = readMockUfcResponse; // function so it can be overridden per-test
-
-  const apiKey = 'dummy';
-  const baseUrl = 'http://127.0.0.1:4000';
-
-  const flagKey = 'mock-experiment';
-  const obfuscatedFlagKey = md5(flagKey);
-
-  const allocationKey = 'traffic-split';
-  const obfuscatedAllocationKey = base64Encode(allocationKey);
-
-  // Configuration for a single flag within the UFC.
-  const mockUfcFlagConfig: Flag = {
-    key: obfuscatedFlagKey,
-    enabled: true,
-    variationType: VariationType.STRING,
-    variations: {
-      [base64Encode('control')]: {
-        key: base64Encode('control'),
-        value: base64Encode('control'),
-      },
-      [base64Encode('variant-1')]: {
-        key: base64Encode('variant-1'),
-        value: base64Encode('variant-1'),
-      },
-      [base64Encode('variant-2')]: {
-        key: base64Encode('variant-2'),
-        value: base64Encode('variant-2'),
-      },
-    },
-    allocations: [
-      {
-        key: obfuscatedAllocationKey,
-        rules: [],
-        splits: [
-          {
-            variationKey: base64Encode('control'),
-            shards: [
-              {
-                salt: base64Encode('some-salt'),
-                ranges: [{ start: 0, end: 3400 }],
-              },
-            ],
-          },
-          {
-            variationKey: base64Encode('variant-1'),
-            shards: [
-              {
-                salt: base64Encode('some-salt'),
-                ranges: [{ start: 3400, end: 6700 }],
-              },
-            ],
-          },
-          {
-            variationKey: base64Encode('variant-2'),
-            shards: [
-              {
-                salt: base64Encode('some-salt'),
-                ranges: [{ start: 6700, end: 10000 }],
-              },
-            ],
-          },
-        ],
-        doLog: true,
-      },
-    ],
-    totalShards: 10000,
-  };
 
   beforeAll(async () => {
     global.fetch = jest.fn(() => {
@@ -127,7 +128,7 @@ describe('EppoJSClient E2E test', () => {
   });
 
   afterEach(() => {
-    returnUfc = readMockUfcResponse;
+    //returnUfc = readMockUfcResponse;
     globalClient.setLogger(mockLogger);
     td.reset();
   });
@@ -138,13 +139,13 @@ describe('EppoJSClient E2E test', () => {
 
   it('returns default value when experiment config is absent', () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    td.replace(EppoLocalStorage.prototype, 'get', (key: string) => null as null);
+    td.replace(HybridConfigurationStore.prototype, 'get', (key: string) => null as null);
     const assignment = globalClient.getStringAssignment(flagKey, 'subject-10', {}, 'default-value');
     expect(assignment).toEqual('default-value');
   });
 
   it('logs variation assignment and experiment key', () => {
-    td.replace(EppoLocalStorage.prototype, 'get', (key: string) => {
+    td.replace(HybridConfigurationStore.prototype, 'get', (key: string) => {
       if (key !== obfuscatedFlagKey) {
         throw new Error('Unexpected key ' + key);
       }
@@ -176,7 +177,7 @@ describe('EppoJSClient E2E test', () => {
   it('handles logging exception', () => {
     const mockLogger = td.object<IAssignmentLogger>();
     td.when(mockLogger.logAssignment(td.matchers.anything())).thenThrow(new Error('logging error'));
-    td.replace(EppoLocalStorage.prototype, 'get', (key: string) => {
+    td.replace(HybridConfigurationStore.prototype, 'get', (key: string) => {
       if (key !== obfuscatedFlagKey) {
         throw new Error('Unexpected key ' + key);
       }
@@ -194,7 +195,7 @@ describe('EppoJSClient E2E test', () => {
   });
 
   it('only returns variation if subject matches rules', () => {
-    td.replace(EppoLocalStorage.prototype, 'get', (key: string) => {
+    td.replace(HybridConfigurationStore.prototype, 'get', (key: string) => {
       if (key !== obfuscatedFlagKey) {
         throw new Error('Unexpected key ' + key);
       }
@@ -290,283 +291,273 @@ describe('EppoJSClient E2E test', () => {
       },
     );
   });
+});
 
-  describe('LocalStorageAssignmentCache', () => {
-    it('typical behavior', () => {
-      const cache = new LocalStorageAssignmentCache();
-      expect(
-        cache.hasLoggedAssignment({
-          subjectKey: 'subject-1',
-          flagKey: 'flag-1',
-          allocationKey: 'allocation-1',
-          variationKey: 'control',
-        }),
-      ).toEqual(false);
+describe('initialization options', () => {
+  let mockLogger: IAssignmentLogger;
+  let returnUfc = readMockUfcResponse; // function so it can be overridden per-test
 
-      cache.setLastLoggedAssignment({
-        subjectKey: 'subject-1',
-        flagKey: 'flag-1',
-        allocationKey: 'allocation-1',
-        variationKey: 'control',
-      });
+  const maxRetryDelay = POLL_INTERVAL_MS * POLL_JITTER_PCT;
+  const mockConfigResponse = {
+    flags: {
+      [obfuscatedFlagKey]: mockUfcFlagConfig,
+    },
+  } as unknown as Record<'flags', Record<string, Flag>>;
 
-      expect(
-        cache.hasLoggedAssignment({
-          subjectKey: 'subject-1',
-          flagKey: 'flag-1',
-          allocationKey: 'allocation-1',
-          variationKey: 'control',
-        }),
-      ).toEqual(true); // this key has been logged
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  let init: Function;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  let getInstance: Function;
 
-      // change variation
-      cache.setLastLoggedAssignment({
-        subjectKey: 'subject-1',
-        flagKey: 'flag-1',
-        allocationKey: 'allocation-1',
-        variationKey: 'variant',
-      });
-
-      expect(
-        cache.hasLoggedAssignment({
-          subjectKey: 'subject-1',
-          flagKey: 'flag-1',
-          allocationKey: 'allocation-1',
-          variationKey: 'control',
-        }),
-      ).toEqual(false); // this key has not been logged
+  beforeEach(async () => {
+    jest.isolateModules(() => {
+      // Isolate and re-require so that the static instance is reset to it's default state
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const reloadedModule = require('./index');
+      init = reloadedModule.init;
+      getInstance = reloadedModule.getInstance;
     });
+
+    global.fetch = jest.fn(() => {
+      const ufc = returnUfc(MOCK_UFC_RESPONSE_FILE);
+
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(ufc),
+      });
+    }) as jest.Mock;
+
+    mockLogger = td.object<IAssignmentLogger>();
+
+    await init({
+      apiKey,
+      baseUrl,
+      assignmentLogger: mockLogger,
+    });
+
+    jest.useFakeTimers({
+      advanceTimers: true,
+      doNotFake: [
+        'Date',
+        'hrtime',
+        'nextTick',
+        'performance',
+        'queueMicrotask',
+        'requestAnimationFrame',
+        'cancelAnimationFrame',
+        'requestIdleCallback',
+        'cancelIdleCallback',
+        'setImmediate',
+        'clearImmediate',
+        'setInterval',
+        'clearInterval',
+      ],
+    });
+
+    // We're creating a new instance for each test so we need to clear the underlying storage too
+    window.localStorage.clear();
   });
 
-  describe('initialization options', () => {
-    const maxRetryDelay = POLL_INTERVAL_MS * POLL_JITTER_PCT;
-    const mockConfigResponse = {
-      flags: {
-        [obfuscatedFlagKey]: mockUfcFlagConfig,
-      },
-    } as unknown as Record<'flags', Record<string, Flag>>;
+  afterEach(() => {
+    td.reset();
+    jest.useRealTimers();
+    jest.clearAllTimers();
+  });
 
-    beforeAll(() => {
-      jest.useFakeTimers({
-        advanceTimers: true,
-        doNotFake: [
-          'Date',
-          'hrtime',
-          'nextTick',
-          'performance',
-          'queueMicrotask',
-          'requestAnimationFrame',
-          'cancelAnimationFrame',
-          'requestIdleCallback',
-          'cancelIdleCallback',
-          'setImmediate',
-          'clearImmediate',
-          'setInterval',
-          'clearInterval',
-        ],
-      });
-    });
+  it('default options', async () => {
+    let callCount = 0;
 
-    beforeEach(() => {
-      // We're creating a new instance for each test so we need to clear the underlying storage too
-      window.localStorage.clear();
-    });
-
-    afterEach(() => {
-      jest.clearAllTimers();
-      td.reset();
-    });
-
-    afterAll(() => {
-      jest.useRealTimers();
-    });
-
-    it('default options', async () => {
-      td.replace(HttpClient.prototype, 'get');
-      let callCount = 0;
-      td.when(HttpClient.prototype.get(td.matchers.anything())).thenDo(() => {
-        if (++callCount === 1) {
-          // Throw an error for the first call
-          throw new Error('Intentional Thrown Error For Test');
-        } else {
-          // Return a mock object for subsequent calls
-          return mockConfigResponse;
-        }
-      });
-
-      // By not awaiting (yet) only the first attempt should be fired off before test execution below resumes
-      const initPromise = init({
-        apiKey,
-        baseUrl,
-        assignmentLogger: mockLogger,
-      });
-
-      // Advance timers mid-init to allow retrying
-      await jest.advanceTimersByTimeAsync(maxRetryDelay);
-
-      // Await so it can finish its initialization before this test proceeds
-      const client = await initPromise;
-      expect(callCount).toBe(2);
-      expect(client.getStringAssignment(flagKey, 'subject', {}, 'default-value')).toBe('control');
-
-      // By default, no more calls
-      await jest.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 10);
-      expect(callCount).toBe(2);
-    });
-
-    it('polls after successful init if configured to do so', async () => {
-      td.replace(HttpClient.prototype, 'get');
-      let callCount = 0;
-      td.when(HttpClient.prototype.get(td.matchers.anything())).thenDo(() => {
-        callCount += 1;
-        return mockConfigResponse;
-      });
-
-      // By not awaiting (yet) only the first attempt should be fired off before test execution below resumes
-      const client = await init({
-        apiKey,
-        baseUrl,
-        assignmentLogger: mockLogger,
-        pollAfterSuccessfulInitialization: true,
-      });
-      expect(callCount).toBe(1);
-      expect(client.getStringAssignment(flagKey, 'subject', {}, 'default-value')).toBe('control');
-
-      // Advance timers mid-init to allow retrying
-      await jest.advanceTimersByTimeAsync(maxRetryDelay);
-
-      // Should be polling
-      await jest.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 10);
-      expect(callCount).toBe(11);
-    });
-
-    it('gives up initial request and throws error after hitting max retries', async () => {
-      td.replace(HttpClient.prototype, 'get');
-      let callCount = 0;
-      td.when(HttpClient.prototype.get(td.matchers.anything())).thenDo(async () => {
-        callCount += 1;
+    global.fetch = jest.fn(() => {
+      if (++callCount === 1) {
         throw new Error('Intentional Thrown Error For Test');
-      });
+      } else {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(mockConfigResponse),
+        });
+      }
+    }) as jest.Mock;
 
-      // Note: fake time does not play well with errors bubbled up after setTimeout (event loop,
-      // timeout queue, message queue stuff) so we don't allow retries when rethrowing.
-      await expect(
-        init({
-          apiKey,
-          baseUrl,
-          assignmentLogger: mockLogger,
-          numInitialRequestRetries: 0,
-        }),
-      ).rejects.toThrow();
-
-      expect(callCount).toBe(1);
-
-      // Assignments resolve to default.
-      const client = getInstance();
-      expect(client.getStringAssignment(flagKey, 'subject', {}, 'default-value')).toBe(
-        'default-value',
-      );
-
-      // Expect no further configuration requests
-      await jest.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
-      expect(callCount).toBe(1);
+    // By not awaiting (yet) only the first attempt should be fired off before test execution below resumes
+    const initPromise = init({
+      apiKey,
+      baseUrl,
+      assignmentLogger: mockLogger,
     });
 
-    it('gives up initial request but still polls later if configured to do so', async () => {
-      td.replace(HttpClient.prototype, 'get');
-      let callCount = 0;
-      td.when(HttpClient.prototype.get(td.matchers.anything())).thenDo(() => {
-        if (++callCount <= 2) {
-          // Throw an error for the first call
-          throw new Error('Intentional Thrown Error For Test');
-        } else {
-          // Return a mock object for subsequent calls
-          return mockConfigResponse;
-        }
-      });
+    // Advance timers mid-init to allow retrying
+    await jest.advanceTimersByTimeAsync(maxRetryDelay);
 
-      // By not awaiting (yet) only the first attempt should be fired off before test execution below resumes
-      const initPromise = init({
+    // Await so it can finish its initialization before this test proceeds
+    const client = await initPromise;
+    expect(callCount).toBe(2);
+    expect(client.getStringAssignment(flagKey, 'subject', {}, 'default-value')).toBe('control');
+
+    // By default, no more calls
+    await jest.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 10);
+    expect(callCount).toBe(2);
+  });
+
+  it('polls after successful init if configured to do so', async () => {
+    let callCount = 0;
+
+    global.fetch = jest.fn(() => {
+      callCount += 1;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockConfigResponse),
+      });
+    }) as jest.Mock;
+
+    // By not awaiting (yet) only the first attempt should be fired off before test execution below resumes
+    const client = await init({
+      apiKey,
+      baseUrl,
+      assignmentLogger: mockLogger,
+      pollAfterSuccessfulInitialization: true,
+    });
+    expect(callCount).toBe(1);
+    expect(client.getStringAssignment(flagKey, 'subject', {}, 'default-value')).toBe('control');
+
+    // Advance timers mid-init to allow retrying
+    await jest.advanceTimersByTimeAsync(maxRetryDelay);
+
+    // Should be polling
+    await jest.advanceTimersByTimeAsync(POLL_INTERVAL_MS * 10);
+    expect(callCount).toBe(11);
+  });
+
+  it('gives up initial request and throws error after hitting max retries', async () => {
+    let callCount = 0;
+
+    global.fetch = jest.fn(() => {
+      callCount += 1;
+      throw new Error('Intentional Thrown Error For Test');
+    }) as jest.Mock;
+
+    // Note: fake time does not play well with errors bubbled up after setTimeout (event loop,
+    // timeout queue, message queue stuff) so we don't allow retries when rethrowing.
+    await expect(
+      init({
         apiKey,
         baseUrl,
         assignmentLogger: mockLogger,
-        throwOnFailedInitialization: false,
-        pollAfterFailedInitialization: true,
+        numInitialRequestRetries: 0,
+      }),
+    ).rejects.toThrow();
+
+    expect(callCount).toBe(1);
+
+    // Assignments resolve to default.
+    const client = getInstance();
+    expect(client.getStringAssignment(flagKey, 'subject', {}, 'default-value')).toBe(
+      'default-value',
+    );
+
+    // Expect no further configuration requests
+    await jest.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+    expect(callCount).toBe(1);
+  });
+
+  it('gives up initial request but still polls later if configured to do so', async () => {
+    let callCount = 0;
+
+    global.fetch = jest.fn(() => {
+      if (++callCount <= 2) {
+        throw new Error('Intentional Thrown Error For Test');
+      }
+
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockConfigResponse),
+      });
+    }) as jest.Mock;
+
+    // By not awaiting (yet) only the first attempt should be fired off before test execution below resumes
+    const initPromise = init({
+      apiKey,
+      baseUrl,
+      assignmentLogger: mockLogger,
+      throwOnFailedInitialization: false,
+      pollAfterFailedInitialization: true,
+    });
+
+    // Advance timers mid-init to allow retrying
+    await jest.advanceTimersByTimeAsync(maxRetryDelay);
+
+    // Initialization configured to not throw error
+    const client = await initPromise;
+    expect(callCount).toBe(2);
+
+    // Initial assignments resolve to be the default
+    expect(client.getStringAssignment(flagKey, 'subject', {}, 'default-value')).toBe(
+      'default-value',
+    );
+
+    await jest.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
+
+    // Expect a new call from poller
+    expect(callCount).toBe(3);
+
+    // Assignments now working
+    expect(client.getStringAssignment(flagKey, 'subject', {}, 'default-value')).toBe('control');
+  });
+
+  describe('With reloaded index module', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    let init: Function;
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    let getInstance: Function;
+    beforeEach(async () => {
+      jest.isolateModules(() => {
+        // Isolate and re-require so that the static instance is reset to it's default state
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const reloadedModule = require('./index');
+        init = reloadedModule.init;
+        getInstance = reloadedModule.getInstance;
       });
 
-      // Advance timers mid-init to allow retrying
-      await jest.advanceTimersByTimeAsync(maxRetryDelay);
+      global.fetch = jest.fn(() => {
+        const ufc = returnUfc(MOCK_UFC_RESPONSE_FILE);
 
-      // Initialization configured to not throw error
-      const client = await initPromise;
-      expect(callCount).toBe(2);
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve(ufc),
+        });
+      }) as jest.Mock;
 
-      // Initial assignments resolve to be the default
+      mockLogger = td.object<IAssignmentLogger>();
+
+      await init({
+        apiKey,
+        baseUrl,
+        assignmentLogger: mockLogger,
+      });
+    });
+
+    it('returns empty assignments pre-initialization by default', async () => {
+      returnUfc = () => mockConfigResponse;
+      const client = getInstance();
+      expect(client.getStringAssignment(flagKey, 'subject-10', {}, 'default-value')).toBe(
+        'default-value',
+      );
+      // don't await
+      init({
+        apiKey,
+        baseUrl,
+        assignmentLogger: mockLogger,
+      });
       expect(client.getStringAssignment(flagKey, 'subject', {}, 'default-value')).toBe(
         'default-value',
       );
-
+      // Advance time so a poll happened and check again
       await jest.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
-
-      // Expect a new call from poller
-      expect(callCount).toBe(3);
-
-      // Assignments now working
       expect(client.getStringAssignment(flagKey, 'subject', {}, 'default-value')).toBe('control');
-    });
-
-    describe('With reloaded index module', () => {
-      // eslint-disable-next-line @typescript-eslint/ban-types
-      let init: Function;
-      // eslint-disable-next-line @typescript-eslint/ban-types
-      let getInstance: Function;
-      beforeEach(async () => {
-        jest.isolateModules(() => {
-          // Isolate and re-require so that the static instance is reset to it's default state
-          // eslint-disable-next-line @typescript-eslint/no-var-requires
-          const reloadedModule = require('./index');
-          init = reloadedModule.init;
-          getInstance = reloadedModule.getInstance;
-        });
-
-        global.fetch = jest.fn(() => {
-          const ufc = returnUfc(MOCK_UFC_RESPONSE_FILE);
-
-          return Promise.resolve({
-            ok: true,
-            status: 200,
-            json: () => Promise.resolve(ufc),
-          });
-        }) as jest.Mock;
-
-        mockLogger = td.object<IAssignmentLogger>();
-
-        globalClient = await init({
-          apiKey,
-          baseUrl,
-          assignmentLogger: mockLogger,
-        });
-      });
-
-      it('returns empty assignments pre-initialization by default', async () => {
-        returnUfc = () => mockConfigResponse;
-        const client = getInstance();
-        expect(client.getStringAssignment(flagKey, 'subject-10', {}, 'default-value')).toBe(
-          'default-value',
-        );
-        // don't await
-        init({
-          apiKey,
-          baseUrl,
-          assignmentLogger: mockLogger,
-        });
-        expect(client.getStringAssignment(flagKey, 'subject', {}, 'default-value')).toBe(
-          'default-value',
-        );
-        // Advance time so a poll happened and check again
-        await jest.advanceTimersByTimeAsync(POLL_INTERVAL_MS);
-        expect(client.getStringAssignment(flagKey, 'subject', {}, 'default-value')).toBe('control');
-      });
     });
   });
 });

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -128,7 +128,6 @@ describe('EppoJSClient E2E test', () => {
   });
 
   afterEach(() => {
-    //returnUfc = readMockUfcResponse;
     globalClient.setLogger(mockLogger);
     td.reset();
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import {
   FlagConfigurationRequestParameters,
 } from '@eppo/js-client-sdk-common';
 
-import { EppoLocalStorage } from './local-storage';
+import { configurationStorageFactory } from './configuration-factory';
 import { LocalStorageAssignmentCache } from './local-storage-assignment-cache';
 import { sdkName, sdkVersion } from './sdk-data';
 
@@ -68,7 +68,7 @@ export interface IClientConfig {
 
 export { IAssignmentLogger, IAssignmentEvent, IEppoClient } from '@eppo/js-client-sdk-common';
 
-const localStorage = new EppoLocalStorage();
+const localStorage = configurationStorageFactory();
 
 /**
  * Client for assigning experiment variations.

--- a/src/local-storage-assignment-cache.spec.ts
+++ b/src/local-storage-assignment-cache.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { LocalStorageAssignmentCache } from './local-storage-assignment-cache';
+
+describe('LocalStorageAssignmentCache', () => {
+  it('typical behavior', () => {
+    const cache = new LocalStorageAssignmentCache();
+    expect(
+      cache.hasLoggedAssignment({
+        subjectKey: 'subject-1',
+        flagKey: 'flag-1',
+        allocationKey: 'allocation-1',
+        variationKey: 'control',
+      }),
+    ).toEqual(false);
+
+    cache.setLastLoggedAssignment({
+      subjectKey: 'subject-1',
+      flagKey: 'flag-1',
+      allocationKey: 'allocation-1',
+      variationKey: 'control',
+    });
+
+    expect(
+      cache.hasLoggedAssignment({
+        subjectKey: 'subject-1',
+        flagKey: 'flag-1',
+        allocationKey: 'allocation-1',
+        variationKey: 'control',
+      }),
+    ).toEqual(true); // this key has been logged
+
+    // change variation
+    cache.setLastLoggedAssignment({
+      subjectKey: 'subject-1',
+      flagKey: 'flag-1',
+      allocationKey: 'allocation-1',
+      variationKey: 'variant',
+    });
+
+    expect(
+      cache.hasLoggedAssignment({
+        subjectKey: 'subject-1',
+        flagKey: 'flag-1',
+        allocationKey: 'allocation-1',
+        variationKey: 'control',
+      }),
+    ).toEqual(false); // this key has not been logged
+  });
+});

--- a/src/local-storage-assignment-cache.ts
+++ b/src/local-storage-assignment-cache.ts
@@ -1,6 +1,6 @@
 import { AssignmentCache } from '@eppo/js-client-sdk-common';
 
-import { hasWindowLocalStorage } from './local-storage';
+import { hasWindowLocalStorage } from './configuration-factory';
 
 class LocalStorageAssignmentShim {
   LOCAL_STORAGE_KEY = 'EPPO_LOCAL_STORAGE_ASSIGNMENT_CACHE';

--- a/src/local-storage.spec.ts
+++ b/src/local-storage.spec.ts
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { EppoLocalStorage } from './local-storage';
+import { LocalStorageBackedAsyncStore } from './local-storage';
 
 describe('EppoLocalStorage', () => {
   interface ITestEntry {
@@ -15,38 +15,20 @@ describe('EppoLocalStorage', () => {
     items: ['red'],
   };
 
-  const storage = new EppoLocalStorage();
+  const storage = new LocalStorageBackedAsyncStore<ITestEntry>(window.localStorage);
 
   beforeEach(() => {
     window.localStorage.clear();
   });
 
   describe('get and set', () => {
-    it('returns null if entry is not present', () => {
-      expect(storage.get('does not exist')).toEqual(null);
+    it('returns null if entry is not present', async () => {
+      expect(await storage.getEntries()).toEqual(null);
     });
 
-    it('returns null if local storage is not enabled', () => {
-      const {
-        window: { localStorage },
-      } = global;
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      delete global.window.localStorage;
-      storage.setEntries({ key1: config1 });
-      expect(storage.get<ITestEntry>('key1')).toEqual(null);
-      global.window.localStorage = localStorage;
-    });
-
-    it('returns stored entries', () => {
-      storage.setEntries({ key1: config1, key2: config2 });
-      expect(storage.get<ITestEntry>('key1')).toEqual(config1);
-      expect(storage.get<ITestEntry>('key2')).toEqual(config2);
-    });
-
-    it('returns a list of keys', () => {
-      storage.setEntries({ key1: config1, key2: config2 });
-      expect(storage.getKeys()).toEqual(['key1', 'key2']);
+    it('returns stored entries', async () => {
+      await storage.setEntries({ key1: config1, key2: config2 });
+      expect(await storage.getEntries()).toEqual({ key1: config1, key2: config2 });
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,10 +380,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@eppo/js-client-sdk-common@3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-3.0.2.tgz#c1929fcad1b67676657d721cdc37561da108565d"
-  integrity sha512-Px7ppXMiWSNYYBRWORLcPSnOSreZASYzvn58CD1ZmKXDIruEOMD/39OUttDHex+tIj26f/BsVZNJzkR4zaD4Lg==
+"@eppo/js-client-sdk-common@3.0.6":
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-3.0.6.tgz#8d2019d45708b944e26e493f09bcce833925ffa1"
+  integrity sha512-YV32rf2UjNuKDAwyEl2HKearxsHRr2UDOJl+xblq5RCG8KB19xjxlNoUeFHd6FwTmqDVFF998r2DDEzoL496YQ==
   dependencies:
     md5 "^2.3.0"
     pino "^8.19.0"


### PR DESCRIPTION
…torage (FF-1980)

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

* Prepare for user provided persistence stores
* 🐞 Fixes bug where stale keys in `localStorage` were not being removed. All configuration is stored to a single key.

## Description
[//]: # (Describe your changes in detail)

* bump to `commons:3.0.6`
* `LocalStorageBackedAsyncStore` implementation of `IAsyncStore` - while `localStorage` is a sync API, wrap the requests in promises to fit in with our design pattern of persistence stores all being async.
* 🐞 Fixes bug where stale keys in `localStorage` were not being removed. All configuration is stored to a single key.
* `configurationStorageFactory` detects what environment it is executing in and creates the appropriate configuration store.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

* unit and integration tests

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
