### PR TITLE
Revert client instantiate inside of `init` method. Create with empty …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "3.0.2-rc.0",
+  "version": "3.0.2-rc.1",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [
@@ -57,7 +57,7 @@
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {
-    "@eppo/js-client-sdk-common": "3.0.6",
+    "@eppo/js-client-sdk-common": "3.0.8",
     "md5": "^2.3.0"
   }
 }

--- a/src/configuration-factory.ts
+++ b/src/configuration-factory.ts
@@ -11,8 +11,11 @@ import { LocalStorageBackedAsyncStore } from './local-storage';
 
 export function configurationStorageFactory(
   persistenceStore?: IAsyncStore<Flag>,
+  forceMemoryOnly = false,
 ): IConfigurationStore<Flag> {
-  if (persistenceStore) {
+  if (forceMemoryOnly) {
+    return new MemoryOnlyConfigurationStore();
+  } else if (persistenceStore) {
     return new HybridConfigurationStore(new MemoryStore<Flag>(), persistenceStore);
   } else if (hasWindowLocalStorage()) {
     // fallback to window.localStorage if available

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,10 +380,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@eppo/js-client-sdk-common@3.0.6":
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-3.0.6.tgz#8d2019d45708b944e26e493f09bcce833925ffa1"
-  integrity sha512-YV32rf2UjNuKDAwyEl2HKearxsHRr2UDOJl+xblq5RCG8KB19xjxlNoUeFHd6FwTmqDVFF998r2DDEzoL496YQ==
+"@eppo/js-client-sdk-common@3.0.8":
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-3.0.8.tgz#738c67c2ae95d4c8b8b84cd8625ff010e11ac6cc"
+  integrity sha512-Qe7O78Pt2PYyTXMLYQMoGyv0aOu5NdXsO1VWBCjA6aUqkWKyy4etyMy1BXpwsbxH6kvKq1uwTJO19N7zoCVFlQ==
   dependencies:
     md5 "^2.3.0"
     pino "^8.19.0"


### PR DESCRIPTION
…in-memory store. Populate the configuration store in `init`.

---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Client instantiation was pushed from a static method to the `init` function (https://github.com/Eppo-exp/js-client-sdk/commit/b76e8d8f0148cb0238f014a4f866718f2ad10bab)

This means that accessing the instance using `EppoClient.getInstance` before calling `init` provided an `undefined` variable. Making any API calls against it led to crashes.

## Description
[//]: # (Describe your changes in detail)

* Restores client instantiation in the static method so that it is immediately available. We need to select some kind of configuration store - previously this defaulted to `localStorage`. Now I am changing this to load from an empty memory store. This changes the client behavior so that between getting the client and calling `init` it will always evaluate to `null`.
* The `init` method sets the desired configuration store or the factory method detects which environment it is in.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
