### PR TITLE
initialize the configuration store

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "3.0.2-rc.3",
+  "version": "3.0.2-rc.4",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "3.0.2-rc.4",
+  "version": "3.0.2-rc.5",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "3.0.2-rc.2",
+  "version": "3.0.2-rc.3",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "3.0.2-rc.1",
+  "version": "3.0.2-rc.2",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [

--- a/src/chrome.configuration-store.spec.ts
+++ b/src/chrome.configuration-store.spec.ts
@@ -37,13 +37,13 @@ describe('ChromeStore', () => {
     expect(await chromeStore.isExpired()).toBe(true);
   });
 
-  it('should return null when no entries are found', async () => {
+  it('should return empty object when no entries are found', async () => {
     (extendedStorageLocal.get as jest.Mock).mockImplementation(() => {
       return Promise.resolve({});
     });
 
     const entries = await chromeStore.getEntries();
-    expect(entries).toBeNull();
+    expect(entries).toEqual({});
   });
 
   it('should be initialized after setting entries', async () => {

--- a/src/configuration-factory.ts
+++ b/src/configuration-factory.ts
@@ -14,10 +14,13 @@ export function configurationStorageFactory(
   forceMemoryOnly = false,
 ): IConfigurationStore<Flag> {
   if (forceMemoryOnly) {
+    console.log('(forced): Using memory-only configuration store.');
     return new MemoryOnlyConfigurationStore();
   } else if (persistenceStore) {
+    console.log('(persistenceStore): Using user-provided configuration store.');
     return new HybridConfigurationStore(new MemoryStore<Flag>(), persistenceStore);
   } else if (hasWindowLocalStorage()) {
+    console.log('(localStorage): Using window.localStorage configuration store.');
     // fallback to window.localStorage if available
     return new HybridConfigurationStore(
       new MemoryStore<Flag>(),
@@ -25,6 +28,7 @@ export function configurationStorageFactory(
     );
   }
 
+  console.log('(fallback): Using memory-only configuration store.');
   return new MemoryOnlyConfigurationStore();
 }
 

--- a/src/configuration-factory.ts
+++ b/src/configuration-factory.ts
@@ -14,13 +14,10 @@ export function configurationStorageFactory(
   forceMemoryOnly = false,
 ): IConfigurationStore<Flag> {
   if (forceMemoryOnly) {
-    console.log('(forced): Using memory-only configuration store.');
     return new MemoryOnlyConfigurationStore();
   } else if (persistenceStore) {
-    console.log('(persistenceStore): Using user-provided configuration store.');
     return new HybridConfigurationStore(new MemoryStore<Flag>(), persistenceStore);
   } else if (hasWindowLocalStorage()) {
-    console.log('(localStorage): Using window.localStorage configuration store.');
     // fallback to window.localStorage if available
     return new HybridConfigurationStore(
       new MemoryStore<Flag>(),
@@ -28,7 +25,6 @@ export function configurationStorageFactory(
     );
   }
 
-  console.log('(fallback): Using memory-only configuration store.');
   return new MemoryOnlyConfigurationStore();
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -170,6 +170,7 @@ export async function init(config: IClientConfig): Promise<IEppoClient> {
     // Set the configuration store to the desired persistent store, if provided.
     // Otherwise the factory method will detect the current environment and instantiate the correct store.
     const configurationStore = configurationStorageFactory(config.persistentStore, false);
+    await configurationStore.init();
     EppoJSClient.instance.setConfigurationStore(configurationStore);
 
     const requestConfiguration: FlagConfigurationRequestParameters = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,10 +167,16 @@ export async function init(config: IClientConfig): Promise<IEppoClient> {
       EppoJSClient.instance.stopPolling();
     }
 
+    console.log('Initializing Eppo SDK');
+
     // Set the configuration store to the desired persistent store, if provided.
     // Otherwise the factory method will detect the current environment and instantiate the correct store.
     const configurationStore = configurationStorageFactory(config.persistentStore, false);
+    console.log('Using configuration store:', configurationStore);
+
+    console.log('(start) Initializing configuration store');
     await configurationStore.init();
+    console.log('(done) Initialized configuration store');
     EppoJSClient.instance.setConfigurationStore(configurationStore);
 
     const requestConfiguration: FlagConfigurationRequestParameters = {
@@ -193,7 +199,10 @@ export async function init(config: IClientConfig): Promise<IEppoClient> {
     // this can be overridden after initialization.
     EppoJSClient.instance.useCustomAssignmentCache(new LocalStorageAssignmentCache());
     EppoJSClient.instance.setConfigurationRequestParameters(requestConfiguration);
+
+    console.log('(start) Fetching flag configurations');
     await EppoJSClient.instance.fetchFlagConfigurations();
+    console.log('(done) Fetched flag configurations');
   } catch (error) {
     console.warn(
       'Eppo SDK encountered an error initializing, assignment calls will return the default value and not be logged' +

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,16 +167,10 @@ export async function init(config: IClientConfig): Promise<IEppoClient> {
       EppoJSClient.instance.stopPolling();
     }
 
-    console.log('Initializing Eppo SDK');
-
     // Set the configuration store to the desired persistent store, if provided.
     // Otherwise the factory method will detect the current environment and instantiate the correct store.
     const configurationStore = configurationStorageFactory(config.persistentStore, false);
-    console.log('Using configuration store:', configurationStore);
-
-    console.log('(start) Initializing configuration store');
     await configurationStore.init();
-    console.log('(done) Initialized configuration store');
     EppoJSClient.instance.setConfigurationStore(configurationStore);
 
     const requestConfiguration: FlagConfigurationRequestParameters = {
@@ -199,10 +193,7 @@ export async function init(config: IClientConfig): Promise<IEppoClient> {
     // this can be overridden after initialization.
     EppoJSClient.instance.useCustomAssignmentCache(new LocalStorageAssignmentCache());
     EppoJSClient.instance.setConfigurationRequestParameters(requestConfiguration);
-
-    console.log('(start) Fetching flag configurations');
     await EppoJSClient.instance.fetchFlagConfigurations();
-    console.log('(done) Fetched flag configurations');
   } catch (error) {
     console.warn(
       'Eppo SDK encountered an error initializing, assignment calls will return the default value and not be logged' +

--- a/src/local-storage-assignment-cache.ts
+++ b/src/local-storage-assignment-cache.ts
@@ -18,7 +18,7 @@ class LocalStorageAssignmentShim {
       return undefined;
     }
 
-    return this.getCache().get(key) || undefined;
+    return this.getCache().get(key) ?? undefined;
   }
 
   public set(key: string, value: string) {

--- a/src/local-storage-assignment-cache.ts
+++ b/src/local-storage-assignment-cache.ts
@@ -13,12 +13,12 @@ class LocalStorageAssignmentShim {
     return this.getCache().has(key);
   }
 
-  public get(key: string): string {
+  public get(key: string): string | undefined {
     if (!hasWindowLocalStorage()) {
-      return null;
+      return undefined;
     }
 
-    return this.getCache().get(key);
+    return this.getCache().get(key) || undefined;
   }
 
   public set(key: string, value: string) {

--- a/src/local-storage.spec.ts
+++ b/src/local-storage.spec.ts
@@ -22,8 +22,8 @@ describe('EppoLocalStorage', () => {
   });
 
   describe('get and set', () => {
-    it('returns null if entry is not present', async () => {
-      expect(await storage.getEntries()).toEqual(null);
+    it('returns empty object if entry is not present', async () => {
+      expect(await storage.getEntries()).toEqual({});
     });
 
     it('returns stored entries', async () => {

--- a/src/local-storage.ts
+++ b/src/local-storage.ts
@@ -22,10 +22,10 @@ export class LocalStorageBackedAsyncStore<T> implements IAsyncStore<T> {
     return Promise.resolve(true);
   }
 
-  getEntries(): Promise<Record<string, T> | null> {
+  getEntries(): Promise<Record<string, T>> {
     const configuration = this.localStorage.getItem(this.localStorageKey);
     if (!configuration) {
-      return Promise.resolve(null);
+      return Promise.resolve({});
     }
     return Promise.resolve(JSON.parse(configuration));
   }

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -52,16 +52,17 @@ export function getTestAssignments(
 ): { subject: SubjectTestCase; assignment: string | boolean | number | object }[] {
   const assignments: {
     subject: SubjectTestCase;
-    assignment: string | boolean | number | null | object;
+    assignment: string | boolean | number | object;
   }[] = [];
   for (const subject of testCase.subjects) {
-    const assignment = assignmentFn(
-      testCase.flag,
-      subject.subjectKey,
-      subject.subjectAttributes,
-      testCase.defaultValue,
-      obfuscated,
-    );
+    const assignment =
+      assignmentFn(
+        testCase.flag,
+        subject.subjectKey,
+        subject.subjectAttributes,
+        testCase.defaultValue,
+        obfuscated,
+      ) || testCase.defaultValue; // Fallback to defaultValue if null
     assignments.push({ subject: subject, assignment: assignment });
   }
   return assignments;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,8 +8,11 @@
     "target": "es2017",
     "outDir": "dist",
     "noImplicitAny": true,
+    "strictNullChecks": true
   },
-  "include": ["src/**/*.ts"],
+  "include": [
+    "src/**/*.ts"
+  ],
   "exclude": [
     "node_modules",
     "dist",


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

1️⃣  Omitting calling the `init` method on the `IConfigurationStore` means that the `servingStore` is not populated from whatever is present on disk (localStorage, chrome.storage, etc).

Throttling the browser network demonstrates that the flags don't begin evaluating to `true` until after the network request completes, whereas the desired behavior is already locally cached flags should start being evaluated as soon as the disk cache is loaded into memory, before the network request:

https://github.com/Eppo-exp/js-client-sdk/assets/57361/ac3a610c-02c0-4709-8555-ab3427988286

2️⃣ If the persistent store is `null`, which should not have happen if the type checker was strict, the `SyncStore.setEntries` method fails since its implemented to assume a not-null parameter.

👉 This only happen in integration tests but was a useful insight!

## Description
[//]: # (Describe your changes in detail)

* initialize the configuration store, loading the disk cache into memory to begin serving before the network request
* enable strict null checking and conform the return types

## Deployment

Publish a new RC build and deploy it to prod eppo.cloud for dogfooding.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

created an RC release of `3.0.2-rc3` and tested by deploying eppo to qa:

https://github.com/Eppo-exp/js-client-sdk/assets/57361/8a12b18b-227e-4eda-86ec-ac3ec2c0cdcf

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
