### PR TITLE
If localStorage is not available, use a in-memory none expiring assig…

### DIFF
--- a/js-client-sdk.api.md
+++ b/js-client-sdk.api.md
@@ -51,6 +51,8 @@ export { IAssignmentEvent }
 
 export { IAssignmentLogger }
 
+export { IAsyncStore }
+
 // @public
 export interface IClientConfig {
     apiKey: string;

--- a/src/assignment-cache/assignment-cache.factory.ts
+++ b/src/assignment-cache/assignment-cache.factory.ts
@@ -1,0 +1,20 @@
+import { AssignmentCache } from '@eppo/js-client-sdk-common';
+import {
+  Cacheable,
+  NonExpiringInMemoryAssignmentCache,
+} from '@eppo/js-client-sdk-common/dist/assignment-cache';
+
+import { hasWindowLocalStorage } from '../environment';
+
+import { LocalStorageAssignmentCache } from './local-storage-assignment-cache';
+
+export function assignmentCacheFactory(): AssignmentCache<Cacheable> {
+  // todo: implement a chrome.storage cache after updating
+  // the interface to be async.
+  if (hasWindowLocalStorage()) {
+    return new LocalStorageAssignmentCache();
+  }
+
+  // Since this is a client SDK we use the non-expiring cache.
+  return new NonExpiringInMemoryAssignmentCache();
+}

--- a/src/assignment-cache/local-storage-assignment-cache.spec.ts
+++ b/src/assignment-cache/local-storage-assignment-cache.spec.ts
@@ -4,7 +4,7 @@
 
 import { LocalStorageAssignmentCache } from './local-storage-assignment-cache';
 
-describe('LocalStorageAssignmentCache', () => {
+describe('AssignmentCache', () => {
   it('typical behavior', () => {
     const cache = new LocalStorageAssignmentCache();
     expect(

--- a/src/assignment-cache/local-storage-assignment-cache.ts
+++ b/src/assignment-cache/local-storage-assignment-cache.ts
@@ -1,31 +1,17 @@
 import { AssignmentCache } from '@eppo/js-client-sdk-common';
 
-import { hasWindowLocalStorage } from './configuration-factory';
-
 class LocalStorageAssignmentShim {
   LOCAL_STORAGE_KEY = 'EPPO_LOCAL_STORAGE_ASSIGNMENT_CACHE';
 
   public has(key: string): boolean {
-    if (!hasWindowLocalStorage()) {
-      return false;
-    }
-
     return this.getCache().has(key);
   }
 
   public get(key: string): string | undefined {
-    if (!hasWindowLocalStorage()) {
-      return undefined;
-    }
-
     return this.getCache().get(key) ?? undefined;
   }
 
   public set(key: string, value: string) {
-    if (!hasWindowLocalStorage()) {
-      return;
-    }
-
     const cache = this.getCache();
     cache.set(key, value);
     this.setCache(cache);

--- a/src/configuration-factory.ts
+++ b/src/configuration-factory.ts
@@ -48,16 +48,3 @@ export function configurationStorageFactory(
   // No persistence store available, use memory only
   return new MemoryOnlyConfigurationStore();
 }
-
-export function hasChromeStorage(): boolean {
-  return typeof chrome !== 'undefined' && !!chrome.storage;
-}
-
-export function hasWindowLocalStorage(): boolean {
-  try {
-    return typeof window !== 'undefined' && !!window.localStorage;
-  } catch {
-    // Chrome throws an error if local storage is disabled and you try to access it
-    return false;
-  }
-}

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -1,0 +1,12 @@
+export function hasChromeStorage(): boolean {
+  return typeof chrome !== 'undefined' && !!chrome.storage;
+}
+
+export function hasWindowLocalStorage(): boolean {
+  try {
+    return typeof window !== 'undefined' && !!window.localStorage;
+  } catch {
+    // Chrome throws an error if local storage is disabled and you try to access it
+    return false;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,12 +8,9 @@ import {
   IAsyncStore,
 } from '@eppo/js-client-sdk-common';
 
-import {
-  configurationStorageFactory,
-  hasChromeStorage,
-  hasWindowLocalStorage,
-} from './configuration-factory';
-import { LocalStorageAssignmentCache } from './local-storage-assignment-cache';
+import { assignmentCacheFactory } from './assignment-cache/assignment-cache.factory';
+import { configurationStorageFactory } from './configuration-factory';
+import { hasChromeStorage, hasWindowLocalStorage } from './environment';
 import { sdkName, sdkVersion } from './sdk-data';
 
 /**
@@ -209,10 +206,7 @@ export async function init(config: IClientConfig): Promise<IEppoClient> {
     };
 
     EppoJSClient.instance.setLogger(config.assignmentLogger);
-
-    // default behavior is to use a LocalStorage-based assignment cache.
-    // this can be overridden after initialization.
-    EppoJSClient.instance.useCustomAssignmentCache(new LocalStorageAssignmentCache());
+    EppoJSClient.instance.useCustomAssignmentCache(assignmentCacheFactory());
     EppoJSClient.instance.setConfigurationRequestParameters(requestConfiguration);
     await EppoJSClient.instance.fetchFlagConfigurations();
   } catch (error) {


### PR DESCRIPTION
…nment cache (FF-2110)

---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

When `init` is called, a `localStorage` assignment cache is created. However if no `localStorage` is available it always returns non-cachable return values, effectively being no cache. This is going to happen on chrome extensions and other environments without a `localStorage`.

## Description
[//]: # (Describe your changes in detail)

* If no `localStorage` is available, create an in-memory assignment cache. This is an improvement over the current behavior as at least there will be some caching happening, even though it is reset each session.
* extracted helper methods in `environment.ts`
* moved assignment cache files into own directory

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
