### PR TITLE
Have package.json point to correct type file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "/src",
     "!*.spec.ts"
   ],
-  "typings": "dist/js-client-sdk.d.ts",
+  "typings": "dist/index.d.ts",
   "scripts": {
     "lint": "eslint '**/*.{ts,tsx}' '**/*.d.{ts,tsx}' --cache",
     "lint:fix": "eslint --fix '**/*.{ts,tsx}' --cache",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "/src",
     "!*.spec.ts"
   ],
-  "typings": "dist/index.d.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "lint": "eslint '**/*.{ts,tsx}' '**/*.d.{ts,tsx}' --cache",
     "lint:fix": "eslint --fix '**/*.{ts,tsx}' --cache",


### PR DESCRIPTION
_Eppo Internal:_ 
🎟️ **Ticket:* [FF-2505 - Could not find a declaration file for module](https://linear.app/eppo/issue/FF-2505/could-not-find-a-declaration-file-for-module)
🗨️ **Slack:* ["...signals about the declaration file being missing..."](https://eppo-group.slack.com/archives/C04KR1GGE3C/p1719233938647939)

## Motivation and Context
Typescript allows including type information with an npm package using the `types` (or `typings`) field in `package.json`. ([docs](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package))

However, our entry for this field pointed to a non-existent file, which would result in typescript-loader generate the following warning error:

```
[tsl] ERROR in /Users/aaron/Workspace/webpack-demo/src/index.ts(2,38)
      TS2307: Cannot find module '@eppo/js-client-sdk' or its corresponding type declarations.
```      

## Description
To fix this, we point our type file at the correct top-level type file, `index.d.ts`.
To better follow convention, we've also renamed the `typings` field to `types`.

## How has this been tested?
Installing the updated and rebuilt package in a simple test application no-longer has the error.

![image](https://github.com/Eppo-exp/js-client-sdk/assets/417605/6113cc4a-6ada-4060-a767-392a698809a9)
