### PR TITLE
feat: Evaluation Details

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "eslint.format.enable": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [
@@ -56,6 +56,6 @@
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {
-    "@eppo/js-client-sdk-common": "3.5.0"
+    "@eppo/js-client-sdk-common": "4.0.0"
   }
 }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -11,6 +11,7 @@ import {
   HybridConfigurationStore,
   IAsyncStore,
   AssignmentCache,
+  EppoClient,
 } from '@eppo/js-client-sdk-common';
 import * as td from 'testdouble';
 
@@ -31,7 +32,6 @@ import { ServingStoreUpdateStrategy } from './isolatable-hybrid.store';
 import {
   offlineInit,
   IAssignmentLogger,
-  IEppoClient,
   getInstance,
   init,
   IClientConfig,
@@ -171,7 +171,7 @@ const mockObfuscatedUfcFlagConfig: Flag = {
 };
 
 describe('EppoJSClient E2E test', () => {
-  let globalClient: IEppoClient;
+  let globalClient: EppoClient;
   let mockLogger: IAssignmentLogger;
 
   beforeAll(async () => {
@@ -412,9 +412,9 @@ describe('initialization options', () => {
   } as unknown as Record<'flags', Record<string, Flag>>;
 
   // eslint-disable-next-line @typescript-eslint/ban-types
-  let init: (config: IClientConfig) => Promise<IEppoClient>;
+  let init: (config: IClientConfig) => Promise<EppoClient>;
   // eslint-disable-next-line @typescript-eslint/ban-types
-  let getInstance: () => IEppoClient;
+  let getInstance: () => EppoClient;
 
   beforeEach(async () => {
     jest.isolateModules(() => {
@@ -626,7 +626,7 @@ describe('initialization options', () => {
   test.each([false, true])(
     'Wait or not for fetch when cache is expired - %s',
     async (useExpiredCache) => {
-      let updatedStoreEntries = null;
+      let updatedStoreEntries: Record<string, Flag> | null = null;
       const mockStore: IAsyncStore<Flag> = {
         isInitialized() {
           return true;
@@ -816,7 +816,7 @@ describe('initialization options', () => {
     expect(mockStoreEntries).toEqual(mockConfigResponse.flags);
   });
 
-  test.each(['always', 'expired', 'empty'])(
+  test.each(['always', 'expired', 'empty'] as ServingStoreUpdateStrategy[])(
     'Fetch updates cache according to the "%s" update strategy',
     async (updateOnFetch: ServingStoreUpdateStrategy) => {
       // Mock fetch so first call works immediately, and all others takes time

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import {
   IAssignmentLogger,
   validation,
-  IEppoClient,
   EppoClient,
   FlagConfigurationRequestParameters,
   Flag,
@@ -10,6 +9,9 @@ import {
   ObfuscatedFlag,
   ApiEndpoints,
   applicationLogger,
+  IAssignmentDetails,
+  BanditActions,
+  BanditSubjectAttributes,
 } from '@eppo/js-client-sdk-common';
 
 import { assignmentCacheFactory } from './cache/assignment-cache-factory';
@@ -125,9 +127,9 @@ export interface IClientConfigSync {
 
 // Export the common types and classes from the SDK.
 export {
-  IAssignmentLogger,
+  IAssignmentDetails,
   IAssignmentEvent,
-  IEppoClient,
+  IAssignmentLogger,
   IAsyncStore,
   Flag,
   ObfuscatedFlag,
@@ -166,6 +168,16 @@ export class EppoJSClient extends EppoClient {
     return super.getStringAssignment(flagKey, subjectKey, subjectAttributes, defaultValue);
   }
 
+  public getStringAssignmentDetails(
+    flagKey: string,
+    subjectKey: string,
+    subjectAttributes: Record<string, AttributeType>,
+    defaultValue: string,
+  ): IAssignmentDetails<string> {
+    EppoJSClient.getAssignmentInitializationCheck();
+    return super.getStringAssignmentDetails(flagKey, subjectKey, subjectAttributes, defaultValue);
+  }
+
   /**
    * @deprecated Use getBooleanAssignment instead
    */
@@ -188,6 +200,16 @@ export class EppoJSClient extends EppoClient {
     return super.getBooleanAssignment(flagKey, subjectKey, subjectAttributes, defaultValue);
   }
 
+  public getBooleanAssignmentDetails(
+    flagKey: string,
+    subjectKey: string,
+    subjectAttributes: Record<string, AttributeType>,
+    defaultValue: boolean,
+  ): IAssignmentDetails<boolean> {
+    EppoJSClient.getAssignmentInitializationCheck();
+    return super.getBooleanAssignmentDetails(flagKey, subjectKey, subjectAttributes, defaultValue);
+  }
+
   public getIntegerAssignment(
     flagKey: string,
     subjectKey: string,
@@ -196,6 +218,16 @@ export class EppoJSClient extends EppoClient {
   ): number {
     EppoJSClient.getAssignmentInitializationCheck();
     return super.getIntegerAssignment(flagKey, subjectKey, subjectAttributes, defaultValue);
+  }
+
+  public getIntegerAssignmentDetails(
+    flagKey: string,
+    subjectKey: string,
+    subjectAttributes: Record<string, AttributeType>,
+    defaultValue: number,
+  ): IAssignmentDetails<number> {
+    EppoJSClient.getAssignmentInitializationCheck();
+    return super.getIntegerAssignmentDetails(flagKey, subjectKey, subjectAttributes, defaultValue);
   }
 
   public getNumericAssignment(
@@ -208,6 +240,16 @@ export class EppoJSClient extends EppoClient {
     return super.getNumericAssignment(flagKey, subjectKey, subjectAttributes, defaultValue);
   }
 
+  public getNumericAssignmentDetails(
+    flagKey: string,
+    subjectKey: string,
+    subjectAttributes: Record<string, AttributeType>,
+    defaultValue: number,
+  ): IAssignmentDetails<number> {
+    EppoJSClient.getAssignmentInitializationCheck();
+    return super.getNumericAssignmentDetails(flagKey, subjectKey, subjectAttributes, defaultValue);
+  }
+
   public getJSONAssignment(
     flagKey: string,
     subjectKey: string,
@@ -216,6 +258,44 @@ export class EppoJSClient extends EppoClient {
   ): object {
     EppoJSClient.getAssignmentInitializationCheck();
     return super.getJSONAssignment(flagKey, subjectKey, subjectAttributes, defaultValue);
+  }
+
+  public getJSONAssignmentDetails(
+    flagKey: string,
+    subjectKey: string,
+    subjectAttributes: Record<string, AttributeType>,
+    defaultValue: object,
+  ): IAssignmentDetails<object> {
+    EppoJSClient.getAssignmentInitializationCheck();
+    return super.getJSONAssignmentDetails(flagKey, subjectKey, subjectAttributes, defaultValue);
+  }
+
+  public getBanditAction(
+    flagKey: string,
+    subjectKey: string,
+    subjectAttributes: BanditSubjectAttributes,
+    actions: BanditActions,
+    defaultValue: string,
+  ): Omit<IAssignmentDetails<string>, 'evaluationDetails'> {
+    EppoJSClient.getAssignmentInitializationCheck();
+    return super.getBanditAction(flagKey, subjectKey, subjectAttributes, actions, defaultValue);
+  }
+
+  public getBanditActionDetails(
+    flagKey: string,
+    subjectKey: string,
+    subjectAttributes: BanditSubjectAttributes,
+    actions: BanditActions,
+    defaultValue: string,
+  ): IAssignmentDetails<string> {
+    EppoJSClient.getAssignmentInitializationCheck();
+    return super.getBanditActionDetails(
+      flagKey,
+      subjectKey,
+      subjectAttributes,
+      actions,
+      defaultValue,
+    );
   }
 
   private static getAssignmentInitializationCheck() {
@@ -242,7 +322,7 @@ export function buildStorageKeySuffix(apiKey: string): string {
  * @returns a singleton client instance
  * @public
  */
-export function offlineInit(config: IClientConfigSync): IEppoClient {
+export function offlineInit(config: IClientConfigSync): EppoClient {
   const isObfuscated = config.isObfuscated ?? false;
   const throwOnFailedInitialization = config.throwOnFailedInitialization ?? true;
 
@@ -297,7 +377,7 @@ export function offlineInit(config: IClientConfigSync): IEppoClient {
  * @param config - client configuration
  * @public
  */
-export async function init(config: IClientConfig): Promise<IEppoClient> {
+export async function init(config: IClientConfig): Promise<EppoClient> {
   validation.validateNotBlank(config.apiKey, 'API key required');
   let initializationError: Error | undefined;
   const instance = EppoJSClient.instance;
@@ -441,7 +521,7 @@ export async function init(config: IClientConfig): Promise<IEppoClient> {
  * @returns a singleton client instance
  * @public
  */
-export function getInstance(): IEppoClient {
+export function getInstance(): EppoClient {
   return EppoJSClient.instance;
 }
 

--- a/src/isolatable-hybrid.store.ts
+++ b/src/isolatable-hybrid.store.ts
@@ -19,7 +19,7 @@ export class IsolatableHybridConfigurationStore<T> extends HybridConfigurationSt
   }
 
   /** @Override */
-  public async setEntries(entries: Record<string, T>): Promise<void> {
+  public async setEntries(entries: Record<string, T>): Promise<boolean> {
     if (this.persistentStore) {
       // always update persistent store
       await this.persistentStore.setEntries(entries);
@@ -41,5 +41,6 @@ export class IsolatableHybridConfigurationStore<T> extends HybridConfigurationSt
     if (updateServingStore) {
       this.servingStore.setEntries(entries);
     }
+    return updateServingStore;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,10 +380,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@eppo/js-client-sdk-common@3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-3.5.0.tgz#456616067a7044707828eea596cf6915d9c21c71"
-  integrity sha512-uCzPXRq7Z7Ir8a9XDz0YU3TP5F1vKYtKqXSjRjqViDSBBfbdTkHBNh1zeA3hEdpppjQKZHExbV1Stl0rmNWznw==
+"@eppo/js-client-sdk-common@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.0.0.tgz#39dea02745b641915fa4e925d75a12ca5b1e9503"
+  integrity sha512-aMru8KESyNJDU/fm5jVENUhpa1jB88FUncT/xnjgiWPuTLLrpi10Qshoj7Lloi8IjlwFSFMjDjtpuQoLKPpQXA==
   dependencies:
     js-base64 "^3.7.7"
     md5 "^2.3.0"


### PR DESCRIPTION
[Evaluation Reasons - js-client-sdk-common](https://github.com/Eppo-exp/js-client-sdk-common/pull/97)
**Evaluation Reasons - js-client-sdk**
[Evaluation Reasons - node-server-sdk](https://github.com/Eppo-exp/node-server-sdk/pull/62)
[Evaluation Reasons - react-native-sdk](https://github.com/Eppo-exp/react-native-sdk/pull/51)

## Motivation and Context
This implements the "assignment details" functionality for the js-client-sdk. 

## Description
- `IEppoClient` is being removed in `@eppo/js-client-sdk-common@3.4.0`, which required updates
- `IConfigurationStore.setEntries` returns `Promise<boolean>` in `@eppo/js-client-sdk-common@3.4.0` which also requires updates. Resolving with `true` internally tells the configuration store to set the `configFetchedAt` and `configPublishedAt` fields.

## How has this been tested?
Manual testing will be done once @eppo/js-client-sdk-common@3.4.0 is published

