### PR TITLE
Update for updated common SDK

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {
-    "@eppo/js-client-sdk-common": "3.3.3"
+    "@eppo/js-client-sdk-common": "3.5.0"
   }
 }

--- a/src/cache/chrome-storage-assignment-cache.ts
+++ b/src/cache/chrome-storage-assignment-cache.ts
@@ -20,7 +20,8 @@ export default class ChromeStorageAssignmentCache implements BulkReadAssignmentC
     this.storage.set(assignmentCacheKeyToString(entry), assignmentCacheValueToString(entry));
   }
 
-  has(_: AssignmentCacheEntry): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  has(_entry: AssignmentCacheEntry): boolean {
     throw new Error(
       'This should never be called for ChromeStorageAssignmentCache, use getEntries() instead.',
     );

--- a/src/chrome-storage-engine.spec.ts
+++ b/src/chrome-storage-engine.spec.ts
@@ -90,7 +90,7 @@ describe('ChromeStorageStore', () => {
   it('should get entries', async () => {
     fakeStore[fakeStoreContentsKey] = JSON.stringify(mockEntries);
 
-    const entries = await chromeStore.getEntries();
+    const entries = await chromeStore.entries();
     expect(entries).toEqual(mockEntries);
   });
 
@@ -107,17 +107,17 @@ describe('ChromeStorageStore', () => {
     const chromeStoreB = new StringValuedAsyncStore(chromeStorageEngineB, 1);
 
     await chromeStoreA.setEntries({ theKey: 'A' });
-    expect(await chromeStoreA.getEntries()).toEqual({ theKey: 'A' });
+    expect(await chromeStoreA.entries()).toEqual({ theKey: 'A' });
     expect(await chromeStoreA.isExpired()).toBe(false);
-    expect(await chromeStoreB.getEntries()).toEqual({});
+    expect(await chromeStoreB.entries()).toEqual({});
     expect(await chromeStoreB.isExpired()).toBe(true);
 
     await jest.advanceTimersByTimeAsync(2000);
 
     await chromeStoreB.setEntries({ theKey: 'B' });
-    expect(await chromeStoreA.getEntries()).toEqual({ theKey: 'A' });
+    expect(await chromeStoreA.entries()).toEqual({ theKey: 'A' });
     expect(await chromeStoreA.isExpired()).toBe(true);
-    expect(await chromeStoreB.getEntries()).toEqual({ theKey: 'B' });
+    expect(await chromeStoreB.entries()).toEqual({ theKey: 'B' });
     expect(await chromeStoreB.isExpired()).toBe(false);
   });
 });

--- a/src/configuration-factory.spec.ts
+++ b/src/configuration-factory.spec.ts
@@ -18,7 +18,7 @@ describe('configurationStorageFactory', () => {
       set: jest.fn(),
       isInitialized: jest.fn().mockReturnValue(true),
       isExpired: jest.fn().mockReturnValue(false),
-      getEntries: jest.fn().mockReturnValue({}),
+      entries: jest.fn().mockReturnValue({}),
       setEntries: jest.fn(),
     };
     const result = configurationStorageFactory({

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -634,7 +634,7 @@ describe('initialization options', () => {
         async isExpired() {
           return true;
         },
-        async getEntries() {
+        async entries() {
           return {
             'old-key': mockObfuscatedUfcFlagConfig,
           };
@@ -781,7 +781,7 @@ describe('initialization options', () => {
       async isExpired() {
         return true; // triggers a fetch
       },
-      async getEntries() {
+      async entries() {
         return new Promise((resolve) => {
           setTimeout(() => {
             storeLoaded = true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -250,7 +250,11 @@ export function offlineInit(config: IClientConfigSync): IEppoClient {
     const memoryOnlyConfigurationStore = configurationStorageFactory({
       forceMemoryOnly: true,
     });
-    memoryOnlyConfigurationStore.setEntries(config.flagsConfiguration).catch();
+    memoryOnlyConfigurationStore
+      .setEntries(config.flagsConfiguration)
+      .catch((err) =>
+        applicationLogger.warn('Error setting flags for memory-only configuration store', err),
+      );
     EppoJSClient.instance.setFlagConfigurationStore(memoryOnlyConfigurationStore);
 
     // Allow the caller to override the default obfuscated mode, which is false

--- a/src/isolatable-hybrid.store.spec.ts
+++ b/src/isolatable-hybrid.store.spec.ts
@@ -8,13 +8,14 @@ describe('IsolatableHybridConfigurationStore', () => {
     get: jest.fn(),
     getKeys: jest.fn(),
     isInitialized: jest.fn(),
+    entries: jest.fn(),
     setEntries: jest.fn(),
   };
 
   const asyncStoreMock = {
-    getEntries: jest.fn(),
     isInitialized: jest.fn(),
     isExpired: jest.fn(),
+    entries: jest.fn(),
     setEntries: jest.fn(),
   };
 
@@ -36,7 +37,7 @@ describe('IsolatableHybridConfigurationStore', () => {
       it('should initialize the serving store with entries from the persistent store', async () => {
         const entries = { key1: 'value1', key2: 'value2' };
         asyncStoreMock.isInitialized.mockReturnValue(true);
-        asyncStoreMock.getEntries.mockResolvedValue(entries);
+        asyncStoreMock.entries.mockResolvedValue(entries);
 
         await store.init();
 
@@ -86,7 +87,7 @@ describe('IsolatableHybridConfigurationStore', () => {
         asyncStoreMock.isInitialized.mockReturnValue(true);
         asyncStoreMock.isExpired.mockReturnValue(false);
         const initialEntries = { key1: 'init1', key2: 'init2' };
-        asyncStoreMock.getEntries.mockResolvedValue(initialEntries);
+        asyncStoreMock.entries.mockResolvedValue(initialEntries);
 
         await store.init();
         // Expect sync store to be initialized with the empty async store

--- a/src/local-storage.store.spec.ts
+++ b/src/local-storage.store.spec.ts
@@ -29,13 +29,13 @@ describe('LocalStorageStore', () => {
 
   it('returns empty object if entry is not present', async () => {
     const store = new StringValuedAsyncStore<ITestEntry>(localStorageEngine);
-    expect(await store.getEntries()).toEqual({});
+    expect(await store.entries()).toEqual({});
   });
 
   it('returns stored entries', async () => {
     const store = new StringValuedAsyncStore<ITestEntry>(localStorageEngine);
     await store.setEntries({ key1: config1, key2: config2 });
-    expect(await store.getEntries()).toEqual({ key1: config1, key2: config2 });
+    expect(await store.entries()).toEqual({ key1: config1, key2: config2 });
   });
 
   it('is always expired without cooldown', async () => {
@@ -67,17 +67,17 @@ describe('LocalStorageStore', () => {
     const storeB = new StringValuedAsyncStore(localStorageEngineEngineB, 1);
 
     await storeA.setEntries({ theKey: 'A' });
-    expect(await storeA.getEntries()).toEqual({ theKey: 'A' });
+    expect(await storeA.entries()).toEqual({ theKey: 'A' });
     expect(await storeA.isExpired()).toBe(false);
-    expect(await storeB.getEntries()).toEqual({});
+    expect(await storeB.entries()).toEqual({});
     expect(await storeB.isExpired()).toBe(true);
 
     await jest.advanceTimersByTimeAsync(2000);
 
     await storeB.setEntries({ theKey: 'B' });
-    expect(await storeA.getEntries()).toEqual({ theKey: 'A' });
+    expect(await storeA.entries()).toEqual({ theKey: 'A' });
     expect(await storeA.isExpired()).toBe(true);
-    expect(await storeB.getEntries()).toEqual({ theKey: 'B' });
+    expect(await storeB.entries()).toEqual({ theKey: 'B' });
     expect(await storeB.isExpired()).toBe(false);
   });
 });

--- a/src/string-valued.store.ts
+++ b/src/string-valued.store.ts
@@ -41,7 +41,7 @@ export class StringValuedAsyncStore<T> implements IAsyncStore<T> {
     return isExpired;
   }
 
-  public async getEntries(): Promise<Record<string, T>> {
+  public async entries(): Promise<Record<string, T>> {
     const contentsJsonString = await this.storageEngine.getContentsJsonString();
     return contentsJsonString ? JSON.parse(contentsJsonString) : {};
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,10 +380,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@eppo/js-client-sdk-common@3.3.3":
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-3.3.3.tgz#aec92ac7bd2415708fe7dc9667a9c1fb18ba9c3a"
-  integrity sha512-i57MkWSBc/KmT4G9y31541bPotn4nnktRbZv1f3E+W58TfG4NBU0FUhY86n98CTqQ2OBoAwkCMntWede4v4rTQ==
+"@eppo/js-client-sdk-common@3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-3.5.0.tgz#456616067a7044707828eea596cf6915d9c21c71"
+  integrity sha512-uCzPXRq7Z7Ir8a9XDz0YU3TP5F1vKYtKqXSjRjqViDSBBfbdTkHBNh1zeA3hEdpppjQKZHExbV1Stl0rmNWznw==
   dependencies:
     js-base64 "^3.7.7"
     md5 "^2.3.0"


### PR DESCRIPTION
_Eppo Internal_:
🎟️ **Ticket:** [FF-2560 - Update Client SDK for Updated Common SDK](https://linear.app/eppo/issue/FF-2560/update-client-sdk-for-updated-common-sdk)

Some changes made to the shared common SDK affect our client SDK, even if it's not using bandits. These include:
* Additional configuration store parameters for constructing the client
* Renamed the flag store and assignment logger for clarity now that we have bandit stores and loggers

This PR updates uses the latest common SDK and address the above issues. 💪 

It also handled an unrelated rename and fixed a flakey test. 🧹 