### PR TITLE
feat: [do not re-init and perform a network request if the singleton …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -191,6 +191,7 @@ describe('EppoJSClient E2E test', () => {
       apiKey,
       baseUrl,
       assignmentLogger: mockLogger,
+      forceReinitialize: true,
     });
   });
 
@@ -335,6 +336,7 @@ describe('EppoJSClient E2E test', () => {
         apiKey,
         baseUrl,
         assignmentLogger: mockLogger,
+        forceReinitialize: true,
       });
     });
 
@@ -778,6 +780,7 @@ describe('initialization options', () => {
       apiKey,
       baseUrl,
       assignmentLogger: mockLogger,
+      forceReinitialize: true,
     });
 
     expect(fetchCallCount).toBe(1);
@@ -790,6 +793,7 @@ describe('initialization options', () => {
       baseUrl: 'https://thisisabaddomainforthistest.com',
       assignmentLogger: mockLogger,
       useExpiredCache: true,
+      forceReinitialize: true,
     });
 
     // Should serve assignment from cache before fetch even fails
@@ -809,6 +813,7 @@ describe('initialization options', () => {
         baseUrl: 'https://thisisabaddomainforthistest.com',
         assignmentLogger: mockLogger,
         useExpiredCache: true,
+        forceReinitialize: true,
       }),
     ).rejects.toThrow();
   });
@@ -909,6 +914,7 @@ describe('initialization options', () => {
         baseUrl,
         assignmentLogger: mockLogger,
         updateOnFetch,
+        forceReinitialize: true,
       });
 
       expect(fetchCallCount).toBe(1);
@@ -926,6 +932,7 @@ describe('initialization options', () => {
         assignmentLogger: mockLogger,
         updateOnFetch,
         useExpiredCache: true,
+        forceReinitialize: true,
       });
 
       // Should serve assignment from cache before fetch completes
@@ -955,6 +962,7 @@ describe('initialization options', () => {
         assignmentLogger: mockLogger,
         updateOnFetch,
         maxCacheAgeSeconds: fetchResolveDelayMs * 10,
+        forceReinitialize: true,
       });
 
       // No fetch will have been kicked off because of valid cache; previously fetched values will be served
@@ -997,6 +1005,7 @@ describe('initialization options', () => {
         apiKey,
         baseUrl,
         assignmentLogger: mockLogger,
+        forceReinitialize: true,
       });
     });
 
@@ -1010,6 +1019,7 @@ describe('initialization options', () => {
         apiKey,
         baseUrl,
         assignmentLogger: mockLogger,
+        forceReinitialize: true,
       });
       expect(getInstance().getStringAssignment(flagKey, 'subject', {}, 'default-value')).toBe(
         'default-value',

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -494,6 +494,61 @@ describe('initialization options', () => {
     expect(callCount).toBe(2);
   });
 
+  it('do not reinitialize if already initialized', async () => {
+    let callCount = 0;
+
+    global.fetch = jest.fn(() => {
+      callCount += 1;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockConfigResponse),
+      });
+    }) as jest.Mock;
+
+    await init({
+      apiKey,
+      baseUrl,
+      assignmentLogger: mockLogger,
+    });
+
+    await init({
+      apiKey,
+      baseUrl,
+      assignmentLogger: mockLogger,
+    });
+
+    expect(callCount).toBe(1);
+  });
+
+  it('force reinitialize', async () => {
+    let callCount = 0;
+
+    global.fetch = jest.fn(() => {
+      callCount += 1;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockConfigResponse),
+      });
+    }) as jest.Mock;
+
+    await init({
+      apiKey,
+      baseUrl,
+      assignmentLogger: mockLogger,
+    });
+
+    await init({
+      apiKey,
+      baseUrl,
+      assignmentLogger: mockLogger,
+      forceReinitialize: true,
+    });
+
+    expect(callCount).toBe(2);
+  });
+
   it('polls after successful init if configured to do so', async () => {
     let callCount = 0;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -392,12 +392,12 @@ export async function init(config: IClientConfig): Promise<EppoClient> {
     if (EppoJSClient.initialized) {
       if (forceReinitialize) {
         applicationLogger.warn(
-          'Eppo SDK is already initialized. Since forceReinitialize is true, reinitializing.',
+          'Eppo SDK is already initialized, reinitializing since forceReinitialize is true.',
         );
         EppoJSClient.initialized = false;
       } else {
         applicationLogger.warn(
-          'Eppo SDK is already initialized. Since forceReinitialize is false, returning existing instance.',
+          'Eppo SDK is already initialized, skipping reinitialization since forceReinitialize is false.',
         );
         return instance;
       }


### PR DESCRIPTION
…has already been init] (FF-2921)

---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

If a user calls `init` repeatedly, the client will issue multiple network requests. This is not desirable behavior as the configuration and assignment cache are also reset.

To support users explicitly reloading configuration we should offer a dedicated refetch method.

## Description
[//]: # (Describe your changes in detail)

* Default behavior change: if the singleton already has been initialized, defined by the `init` method completing (not taking into account the `AsyncStore` or others), return it immediately without re-instantiating.
* Offers a new flag called `forceReinitialize` - setting to `true` re-instantiates the client. I'm not convinced this is needed for users but is useful for tests.
* Bumped to `3.5.0` since this is new functionality - you can argue that functionality is "breaking" but I view this as a correction. We could even argue to publish it as a bug fix.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

* New unit tests.

## Question for reviewers

1. Should we publish as a patch release?

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
