### PR TITLE
fix: init should not require event ingestion url in sdk key

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -388,7 +388,15 @@ export async function init(config: IClientConfig): Promise<EppoClient> {
       skipInitialPoll: skipInitialRequest,
     };
     instance.setConfigurationRequestParameters(requestConfiguration);
-    instance.setEventDispatcher(newEventDispatcher(apiKey));
+
+    try {
+      instance.setEventDispatcher(newEventDispatcher(apiKey));
+    } catch (eventDispatcherError) {
+      applicationLogger.warn(
+        'Eppo SDK encountered an error initializing the event dispatcher, continuing initialization',
+        eventDispatcherError,
+      );
+    }
 
     // We have two at-bats for initialization: from the configuration store and from fetching
     // We can resolve the initialization promise as soon as either one succeeds

--- a/src/index.ts
+++ b/src/index.ts
@@ -389,6 +389,7 @@ export async function init(config: IClientConfig): Promise<EppoClient> {
     };
     instance.setConfigurationRequestParameters(requestConfiguration);
 
+    // e.g. newDefaultEventDispatcher throws an error if it cannot parse a valid event ingestion URL from the SDK key
     try {
       instance.setEventDispatcher(newEventDispatcher(apiKey));
     } catch (eventDispatcherError) {


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

I was running a script to try out the `init` function and saw the following exception thrown when I invoked `init` with a pre-existing SDK key.

```
Error during initialization test: Error: Unable to parse Event ingestion URL from SDK key
    at newDefaultEventDispatcher (/.../js-client-sdk/node_modules/@eppo/js-client-sdk-common/src/events/default-event-dispatcher.ts:138:11)
```

I think the SDK should continue to support old keys, or at least handle the exception so it doesn't get thrown outside the SDK's scope

## Description
[//]: # (Describe your changes in detail)

Here, I propose wrapping the event dispatcher instantiation with a try-catch. Other approaches, like handling this in `js-client-sdk-common` may be valid too

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
