### PR TITLE
chore: Clean up missing release tag warnings

### DIFF
--- a/docs/js-client-sdk.buildstoragekeysuffix.md
+++ b/docs/js-client-sdk.buildstoragekeysuffix.md
@@ -4,6 +4,8 @@
 
 ## buildStorageKeySuffix() function
 
+Builds a storage key suffix from an API key.
+
 **Signature:**
 
 ```typescript
@@ -40,10 +42,14 @@ string
 
 </td><td>
 
+The API key to build the suffix from
+
 
 </td></tr>
 </tbody></table>
 **Returns:**
 
 string
+
+A string suffix for storage keys
 

--- a/docs/js-client-sdk.iclientconfigsync.md
+++ b/docs/js-client-sdk.iclientconfigsync.md
@@ -4,6 +4,8 @@
 
 ## IClientConfigSync interface
 
+Configuration interface for synchronous client initialization.
+
 **Signature:**
 
 ```typescript

--- a/docs/js-client-sdk.md
+++ b/docs/js-client-sdk.md
@@ -76,6 +76,8 @@ Description
 
 </td><td>
 
+Builds a storage key suffix from an API key.
+
 
 </td></tr>
 <tr><td>
@@ -180,6 +182,8 @@ Configuration for regular client initialization
 
 
 </td><td>
+
+Configuration interface for synchronous client initialization.
 
 
 </td></tr>

--- a/js-client-sdk.api.md
+++ b/js-client-sdk.api.md
@@ -20,7 +20,7 @@ import { IAsyncStore } from '@eppo/js-client-sdk-common';
 import { IContainerExperiment } from '@eppo/js-client-sdk-common';
 import { ObfuscatedFlag } from '@eppo/js-client-sdk-common';
 
-// @public (undocumented)
+// @public
 export function buildStorageKeySuffix(apiKey: string): string;
 
 // Warning: (ae-forgotten-export) The symbol "IStringStorageEngine" needs to be exported by the entry point index.d.ts
@@ -125,7 +125,7 @@ export interface IClientConfig extends IBaseRequestConfig {
     useExpiredCache?: boolean;
 }
 
-// @public (undocumented)
+// @public
 export interface IClientConfigSync {
     // (undocumented)
     assignmentLogger?: IAssignmentLogger;

--- a/src/chrome-storage-engine.ts
+++ b/src/chrome-storage-engine.ts
@@ -11,6 +11,7 @@ import { IStringStorageEngine } from './string-valued.store';
  *
  * Note: this behaves a bit differently than local storage as the chrome storage API gets and sets
  * subsets of key-value pairs, so we have to dereference or re-specify the key.
+ * @public
  */
 export class ChromeStorageEngine implements IStringStorageEngine {
   private readonly contentsKey;

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,10 @@ import LocalStorageBackedNamedEventQueue from './events/local-storage-backed-nam
 import { IClientConfig, IPrecomputedClientConfig } from './i-client-config';
 import { sdkName, sdkVersion } from './sdk-data';
 
+/**
+ * Configuration interface for synchronous client initialization.
+ * @public
+ */
 export interface IClientConfigSync {
   flagsConfiguration: Record<string, Flag | ObfuscatedFlag>;
 
@@ -235,6 +239,12 @@ export class EppoJSClient extends EppoClient {
   }
 }
 
+/**
+ * Builds a storage key suffix from an API key.
+ * @param apiKey - The API key to build the suffix from
+ * @returns A string suffix for storage keys
+ * @public
+ */
 export function buildStorageKeySuffix(apiKey: string): string {
   // Note that we use the first 8 characters of the API key to create per-API key persistent storages and caches
   return apiKey.replace(/\W/g, '').substring(0, 8);


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

## Description
[//]: # (Describe your changes in detail)

Removes the following `ae-missing-release-tag` warnings when `api-extractor` runs

```
Warning: src/chrome-storage-engine.ts:15:1 - (ae-missing-release-tag) "ChromeStorageEngine" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
Warning: src/index.ts:37:1 - (ae-missing-release-tag) "IClientConfigSync" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
Warning: src/index.ts:238:1 - (ae-missing-release-tag) "buildStorageKeySuffix" is part of the package's API, but it is missing a release tag (@alpha, @beta, @public, or @internal)
```

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
