### PR TITLE
fix: prevent chrome storage resolving before entries are set

### DIFF
--- a/src/cache/chrome-storage-async-map.spec.ts
+++ b/src/cache/chrome-storage-async-map.spec.ts
@@ -90,7 +90,7 @@ describe('ChromeStorageAsyncMap', () => {
       // Mock successful storage.set
       (mockStorage.set as jest.Mock).mockResolvedValue(undefined);
 
-      // Start the set operation
+      // Create the set operation Promise
       const setPromise = storageMap.set(key, value);
 
       // Verify entry is not written yet

--- a/src/cache/chrome-storage-async-map.spec.ts
+++ b/src/cache/chrome-storage-async-map.spec.ts
@@ -37,28 +37,6 @@ describe('ChromeStorageAsyncMap', () => {
   });
 
   describe('set', () => {
-    it('should resolve when storage change event fires', async () => {
-      const key = 'testKey';
-      const value = 'testValue';
-
-      // Mock successful storage.set
-      (mockStorage.set as jest.Mock).mockResolvedValue(undefined);
-
-      // Start the set operation
-      const setPromise = storageMap.set(key, value);
-
-      // Simulate the storage change event
-      if (storedListener) {
-        storedListener({ [key]: { newValue: value, oldValue: undefined } }, 'local');
-      }
-
-      // Wait for set to complete
-      await setPromise;
-
-      // Verify storage.set was called
-      expect(mockStorage.set).toHaveBeenCalledWith({ [key]: value });
-    });
-
     it('should reject on timeout', async () => {
       const key = 'testKey';
       const value = 'testValue';
@@ -85,7 +63,7 @@ describe('ChromeStorageAsyncMap', () => {
       await expect(storageMap.set(key, value)).rejects.toThrow('Storage error');
     });
 
-    it('should resolve when storage change event fires', async () => {
+    it('should ensure data integrity during write process', async () => {
       const key = 'testKey';
       const value = 'testValue';
       let writeCompleted = false;

--- a/src/cache/chrome-storage-async-map.spec.ts
+++ b/src/cache/chrome-storage-async-map.spec.ts
@@ -4,69 +4,37 @@ import { applicationLogger } from '@eppo/js-client-sdk-common';
 
 import ChromeStorageAsyncMap from './chrome-storage-async-map';
 
-type StorageChangeListener = (
-  changes: { [key: string]: chrome.storage.StorageChange },
-  areaName: string,
-) => void;
-
 describe('ChromeStorageAsyncMap', () => {
-  let storedListener: StorageChangeListener | null = null;
-
   const mockStorage = {
-    get: jest.fn(),
     set: jest.fn(),
   } as unknown as chrome.storage.StorageArea;
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    jest.spyOn(applicationLogger, 'warn').mockImplementation();
-    storedListener = null;
-    global.chrome = {
-      storage: {
-        onChanged: {
-          addListener: (listener: StorageChangeListener) => {
-            storedListener = listener;
-          },
-          removeListener: jest.fn(),
-        },
-      },
-    } as unknown as typeof chrome;
-  });
 
   let storageMap: ChromeStorageAsyncMap<string>;
 
   beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(applicationLogger, 'warn').mockImplementation();
+    (mockStorage.set as jest.Mock).mockImplementation(() => Promise.resolve());
     storageMap = new ChromeStorageAsyncMap(mockStorage);
   });
 
   describe('set', () => {
-    it('should complete without error on timeout', async () => {
+    it('should store and retrieve values correctly', async () => {
       const key = 'testKey';
       const value = 'testValue';
 
-      // Mock successful storage.set but don't trigger change event
-      (mockStorage.set as jest.Mock).mockResolvedValue(undefined);
-
       await storageMap.set(key, value);
+      expect(mockStorage.set).toHaveBeenCalledWith({ [key]: value });
+    });
 
-      // Verify warning was logged
-      expect(applicationLogger.warn).toHaveBeenCalledWith(
-        'Chrome storage write timeout for key:',
-        key,
-      );
-    }, 10000);
-
-    it('should complete without error if storage.set fails', async () => {
+    it('should propagate storage errors', async () => {
       const key = 'testKey';
       const value = 'testValue';
       const error = new Error('Storage error');
 
-      // Mock failed storage.set
       (mockStorage.set as jest.Mock).mockRejectedValue(error);
 
-      await storageMap.set(key, value);
-
-      // Verify warning was logged
+      await expect(storageMap.set(key, value)).rejects.toThrow(error);
       expect(applicationLogger.warn).toHaveBeenCalledWith(
         'Chrome storage write failed for key:',
         key,
@@ -74,40 +42,17 @@ describe('ChromeStorageAsyncMap', () => {
       );
     });
 
-    it('should ensure data integrity during write process', async () => {
-      const key = 'testKey';
-      const value = 'testValue';
-      let writeCompleted = false;
+    it('should handle multiple keys independently', async () => {
+      const key1 = 'testKey1';
+      const value1 = 'testValue1';
+      const key2 = 'testKey2';
+      const value2 = 'testValue2';
 
-      // Mock storage.get to return different values before and after the change event
-      (mockStorage.get as jest.Mock).mockImplementation(async () => {
-        if (!writeCompleted) {
-          return {}; // Entry not yet written
-        }
-        return { [key]: value }; // Entry written after change event
-      });
+      await storageMap.set(key1, value1);
+      await storageMap.set(key2, value2);
 
-      // Mock successful storage.set
-      (mockStorage.set as jest.Mock).mockResolvedValue(undefined);
-
-      // Create the set operation Promise
-      const setPromise = storageMap.set(key, value);
-
-      // Verify entry is not written yet
-      expect(await storageMap.get(key)).toBeUndefined();
-
-      // Simulate the storage change event
-      if (storedListener) {
-        writeCompleted = true;
-        storedListener({ [key]: { newValue: value, oldValue: undefined } }, 'local');
-      }
-
-      // Wait for set to complete
-      await setPromise;
-
-      // Verify entry is now written
-      expect(await storageMap.get(key)).toBe(value);
-      expect(mockStorage.set).toHaveBeenCalledWith({ [key]: value });
+      expect(mockStorage.set).toHaveBeenCalledWith({ [key1]: value1 });
+      expect(mockStorage.set).toHaveBeenCalledWith({ [key2]: value2 });
     });
   });
 });

--- a/src/cache/chrome-storage-async-map.spec.ts
+++ b/src/cache/chrome-storage-async-map.spec.ts
@@ -1,0 +1,124 @@
+/// <reference types="chrome"/>
+
+import ChromeStorageAsyncMap from './chrome-storage-async-map';
+
+type StorageChangeListener = (
+  changes: { [key: string]: chrome.storage.StorageChange },
+  areaName: string,
+) => void;
+
+describe('ChromeStorageAsyncMap', () => {
+  let storedListener: StorageChangeListener | null = null;
+
+  const mockStorage = {
+    get: jest.fn(),
+    set: jest.fn(),
+  } as unknown as chrome.storage.StorageArea;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    storedListener = null;
+    global.chrome = {
+      storage: {
+        onChanged: {
+          addListener: (listener: StorageChangeListener) => {
+            storedListener = listener;
+          },
+          removeListener: jest.fn(),
+        },
+      },
+    } as unknown as typeof chrome;
+  });
+
+  let storageMap: ChromeStorageAsyncMap<string>;
+
+  beforeEach(() => {
+    storageMap = new ChromeStorageAsyncMap(mockStorage);
+  });
+
+  describe('set', () => {
+    it('should resolve when storage change event fires', async () => {
+      const key = 'testKey';
+      const value = 'testValue';
+
+      // Mock successful storage.set
+      (mockStorage.set as jest.Mock).mockResolvedValue(undefined);
+
+      // Start the set operation
+      const setPromise = storageMap.set(key, value);
+
+      // Simulate the storage change event
+      if (storedListener) {
+        storedListener({ [key]: { newValue: value, oldValue: undefined } }, 'local');
+      }
+
+      // Wait for set to complete
+      await setPromise;
+
+      // Verify storage.set was called
+      expect(mockStorage.set).toHaveBeenCalledWith({ [key]: value });
+    });
+
+    it('should reject on timeout', async () => {
+      const key = 'testKey';
+      const value = 'testValue';
+
+      // Mock successful storage.set but don't trigger change event
+      (mockStorage.set as jest.Mock).mockResolvedValue(undefined);
+
+      // Attempt to set value
+      const setPromise = storageMap.set(key, value);
+
+      // Wait for timeout
+      await expect(setPromise).rejects.toThrow('Chrome storage write timeout');
+    });
+
+    it('should reject if storage.set fails', async () => {
+      const key = 'testKey';
+      const value = 'testValue';
+
+      // Mock failed storage.set
+      const error = new Error('Storage error');
+      (mockStorage.set as jest.Mock).mockRejectedValue(error);
+
+      // Attempt to set value
+      await expect(storageMap.set(key, value)).rejects.toThrow('Storage error');
+    });
+
+    it('should resolve when storage change event fires', async () => {
+      const key = 'testKey';
+      const value = 'testValue';
+      let writeCompleted = false;
+
+      // Mock storage.get to return different values before and after the change event
+      (mockStorage.get as jest.Mock).mockImplementation(async () => {
+        if (!writeCompleted) {
+          return {}; // Entry not yet written
+        }
+        return { [key]: value }; // Entry written after change event
+      });
+
+      // Mock successful storage.set
+      (mockStorage.set as jest.Mock).mockResolvedValue(undefined);
+
+      // Start the set operation
+      const setPromise = storageMap.set(key, value);
+
+      // Verify entry is not written yet
+      expect(await storageMap.get(key)).toBeUndefined();
+
+      // Simulate the storage change event
+      if (storedListener) {
+        writeCompleted = true;
+        storedListener({ [key]: { newValue: value, oldValue: undefined } }, 'local');
+      }
+
+      // Wait for set to complete
+      await setPromise;
+
+      // Verify entry is now written
+      expect(await storageMap.get(key)).toBe(value);
+      expect(mockStorage.set).toHaveBeenCalledWith({ [key]: value });
+    });
+  });
+});

--- a/src/cache/chrome-storage-async-map.ts
+++ b/src/cache/chrome-storage-async-map.ts
@@ -34,7 +34,7 @@ export default class ChromeStorageAsyncMap<T> implements AsyncMap<string, T> {
       const timeout = setTimeout(() => {
         chrome.storage.onChanged.removeListener(listener);
         reject(new Error('Chrome storage write timeout'));
-      }, 5000); // 5 second timeout
+      }, 1000); // 1 second timeout
 
       // Perform the write
       this.storage.set({ [key]: value }).catch((error) => {

--- a/src/cache/chrome-storage-async-map.ts
+++ b/src/cache/chrome-storage-async-map.ts
@@ -20,34 +20,10 @@ export default class ChromeStorageAsyncMap<T> implements AsyncMap<string, T> {
 
   async set(key: string, value: T): Promise<void> {
     try {
-      await new Promise<void>((resolve) => {
-        // Set up listener for this specific write
-        const listener = (changes: { [key: string]: chrome.storage.StorageChange }) => {
-          if (changes[key]) {
-            chrome.storage.onChanged.removeListener(listener);
-            resolve();
-          }
-        };
-
-        chrome.storage.onChanged.addListener(listener);
-
-        // Set a timeout in case the change event never fires
-        const timeout = setTimeout(() => {
-          chrome.storage.onChanged.removeListener(listener);
-          applicationLogger.warn('Chrome storage write timeout for key:', key);
-          resolve();
-        }, 1000);
-
-        // Perform the write
-        this.storage.set({ [key]: value }).catch((error) => {
-          clearTimeout(timeout);
-          chrome.storage.onChanged.removeListener(listener);
-          applicationLogger.warn('Chrome storage write failed for key:', key, error);
-          resolve();
-        });
-      });
+      await this.storage.set({ [key]: value });
     } catch (error) {
-      applicationLogger.warn('Unexpected error in ChromeStorageAsyncMap.set:', error);
+      applicationLogger.warn('Chrome storage write failed for key:', key, error);
+      throw error;
     }
   }
 }

--- a/src/cache/chrome-storage-async-map.ts
+++ b/src/cache/chrome-storage-async-map.ts
@@ -18,7 +18,30 @@ export default class ChromeStorageAsyncMap<T> implements AsyncMap<string, T> {
     return await this.storage.get(null);
   }
 
-  async set(key: string, value: T) {
-    await this.storage.set({ [key]: value });
+  async set(key: string, value: T): Promise<void> {
+    return new Promise((resolve, reject) => {
+      // Set up listener for this specific write
+      const listener = (changes: { [key: string]: chrome.storage.StorageChange }) => {
+        if (changes[key]) {
+          chrome.storage.onChanged.removeListener(listener);
+          resolve();
+        }
+      };
+
+      chrome.storage.onChanged.addListener(listener);
+
+      // Set a timeout in case the change event never fires
+      const timeout = setTimeout(() => {
+        chrome.storage.onChanged.removeListener(listener);
+        reject(new Error('Chrome storage write timeout'));
+      }, 5000); // 5 second timeout
+
+      // Perform the write
+      this.storage.set({ [key]: value }).catch((error) => {
+        clearTimeout(timeout);
+        chrome.storage.onChanged.removeListener(listener);
+        reject(error);
+      });
+    });
   }
 }


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

We had a hypothesis in a debugging session that `await this.storage.set` may be resolving when the writing process starts, instead of when it finishes writing the fetched flags to storage and that this may be an idiosyncratic behavior of the Chrome storage implementation. If true, this could result in inconsistent, null assignments on application start if get assignment is called immediately after `await init`

## Description
[//]: # (Describe your changes in detail)

This is a draft of using an `isInProcessOfInitializing` method to wait before deciding if the store is usable

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
