### PR TITLE
Bump common version to allow handling of special characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "webpack-cli": "^4.10.0"
   },
   "dependencies": {
-    "@eppo/js-client-sdk-common": "^4.6.3"
+    "@eppo/js-client-sdk-common": "^4.7.1"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/events/local-storage-backed-named-event-queue.ts
+++ b/src/events/local-storage-backed-named-event-queue.ts
@@ -47,7 +47,10 @@ export default class LocalStorageBackedNamedEventQueue<T> implements NamedEventQ
     if (this.eventKeys.length === 0) {
       return undefined;
     }
-    const eventKey = this.eventKeys.shift()!;
+    const eventKey = this.eventKeys.shift();
+    if (eventKey === undefined) {
+      throw new Error('Unexpected undefined event key');
+    }
     const eventData = localStorage.getItem(eventKey);
     if (eventData) {
       localStorage.removeItem(eventKey);

--- a/src/events/local-storage-backed-named-event-queue.ts
+++ b/src/events/local-storage-backed-named-event-queue.ts
@@ -48,7 +48,7 @@ export default class LocalStorageBackedNamedEventQueue<T> implements NamedEventQ
       return undefined;
     }
     const eventKey = this.eventKeys.shift();
-    if (eventKey === undefined) {
+    if (!eventKey) {
       throw new Error('Unexpected undefined event key');
     }
     const eventData = localStorage.getItem(eventKey);

--- a/src/i-client-config.ts
+++ b/src/i-client-config.ts
@@ -1,5 +1,4 @@
 import { AttributeType, Flag, IAssignmentLogger, IAsyncStore } from '@eppo/js-client-sdk-common';
-import { EventDispatcherConfig } from '@eppo/js-client-sdk-common/src/events/default-event-dispatcher';
 
 import { ServingStoreUpdateStrategy } from './isolatable-hybrid.store';
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1188,8 +1188,8 @@ describe('EppoClient config', () => {
         json: () => Promise.resolve({}),
       });
     }) as jest.Mock;
-    EppoJSClient.initialized = false;
     const client = await init({
+      forceReinitialize: true,
       apiKey: 'zCsQuoHJxVPp895.ZWg9MTIzNDU2LmUudGVzdGluZy5lcHBvLmNsb3Vk',
       assignmentLogger: td.object<IAssignmentLogger>(),
       eventIngestionConfig: {
@@ -1197,7 +1197,7 @@ describe('EppoClient config', () => {
         retryIntervalMs: 2,
         maxRetryDelayMs: 3,
         maxRetries: 4,
-        batchSize: 5,
+        batchSize: 500,
       },
     });
     // hack to read the private class members config
@@ -1205,7 +1205,7 @@ describe('EppoClient config', () => {
     const retryManager = eventDispatcher['retryManager'];
     const batchProcessor = eventDispatcher['batchProcessor'];
     expect(eventDispatcher['deliveryIntervalMs']).toEqual(1);
-    expect(batchProcessor['batchSize']).toEqual(5);
+    expect(batchProcessor['batchSize']).toEqual(500);
     expect(retryManager['config']['retryIntervalMs']).toEqual(2);
     expect(retryManager['config']['maxRetryDelayMs']).toEqual(3);
     expect(retryManager['config']['maxRetries']).toEqual(4);

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -29,7 +29,6 @@ import { IClientConfig } from './i-client-config';
 import { ServingStoreUpdateStrategy } from './isolatable-hybrid.store';
 
 import {
-  EppoJSClient,
   EppoPrecomputedJSClient,
   getConfigUrl,
   getInstance,

--- a/src/index.ts
+++ b/src/index.ts
@@ -465,8 +465,8 @@ export async function init(config: IClientConfig): Promise<EppoClient> {
       // both failed, make the "fatal" error the fetch one
       initializationError = initFromFetchError;
     }
-  } catch (error: any) {
-    initializationError = error;
+  } catch (error: unknown) {
+    initializationError = error instanceof Error ? error : new Error(String(error));
   }
 
   if (initializationError) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,10 +380,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
-"@eppo/js-client-sdk-common@^4.6.3":
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.6.3.tgz#89267a1c247bc04725b7701cdfb573613c133ddc"
-  integrity sha512-e2nSvzONjqUiAYUjBMIIk1jWuKPOmBl5AlbiNjsoJAd6dZKN1RWpTmy83hNk6ff/syjAEWTcplls2cU37VbyiQ==
+"@eppo/js-client-sdk-common@^4.7.1":
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.7.1.tgz#8a0776055604af65d0e0f8410d4756aa3117992f"
+  integrity sha512-8+5WbFN1EvsS5Ba/qakjDGEhp9loTxSvVHeWaQXKKLXxV+5AhFNOl+d8jSwOkLnP+Qr5D9w1eO7lfzuNDkUcWw==
   dependencies:
     buffer "npm:@eppo/buffer@6.2.0"
     js-base64 "^3.7.7"


### PR DESCRIPTION
_Eppo Internal:_
🎟️ **Ticket:** [FF-3767 - Update JS Client to use updated Common JS for special character handling](https://linear.app/eppo/issue/FF-3767/update-js-client-to-use-updated-common-js-for-special-character)
🗨️ **Slack Thread:** ["...flag text encoding problem..."](https://eppo-group.slack.com/archives/C0541NTN6QH/p1735566355776199)
👯 **Related PR:** [`js-sdk-common #187`](https://github.com/Eppo-exp/js-sdk-common/pull/187)

## Motivation and Context
SDKs need to be able to handle special, non-ASCII characters. This PR adds a test that checks that by using strings with characters from a variety of languages as well as emojis, which all have non-ASCII values.

## Description
We update our common module which switches from using [`js-base64`](https://www.npmjs.com/package/js-base64)'s `btoaPolyfill()` and `atobPolyfill()` to `encode` and `decode` respectively.

The former is designed only to handle ASCII characters and bytes ([docs](https://github.com/dankogai/js-base64?tab=readme-ov-file#decode-vs-atob-and-encode-vs-btoa)), while the latter is designed for strings and can handle all characters. 

Also in here are some linter-suggested fixes

## How has this been tested?
[Updated shared test case](https://github.com/Eppo-exp/sdk-test-data/pull/103)
