### PR TITLE
fix: allow empty string for precomputedConfiguration

### DIFF
--- a/docs/js-client-sdk.iprecomputedclientconfigsync.md
+++ b/docs/js-client-sdk.iprecomputedclientconfigsync.md
@@ -8,6 +8,8 @@ Configuration parameters for initializing the Eppo precomputed client.
 
 This interface is used for cases where precomputed assignments are available from an external process that can bootstrap the SDK client.
 
+ precomputedConfiguration - The configuration as a string to bootstrap the client.  assignmentLogger - Optional logger for assignment events.  throwOnFailedInitialization - Optional flag to throw an error if initialization fails.
+
 **Signature:**
 
 ```typescript

--- a/docs/js-client-sdk.md
+++ b/docs/js-client-sdk.md
@@ -224,6 +224,8 @@ Configuration parameters for initializing the Eppo precomputed client.
 
 This interface is used for cases where precomputed assignments are available from an external process that can bootstrap the SDK client.
 
+ precomputedConfiguration - The configuration as a string to bootstrap the client.  assignmentLogger - Optional logger for assignment events.  throwOnFailedInitialization - Optional flag to throw an error if initialization fails.
+
 
 </td></tr>
 </tbody></table>

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1342,4 +1342,25 @@ describe('EppoClient config', () => {
     expect(retryManager['config']['maxRetryDelayMs']).toEqual(3);
     expect(retryManager['config']['maxRetries']).toEqual(4);
   });
+
+  it('handles empty precomputed configuration string', () => {
+    // Test with throwOnFailedInitialization = true (default)
+    expect(() =>
+      offlinePrecomputedInit({
+        precomputedConfiguration: '',
+      }),
+    ).toThrow('Invalid precomputed configuration wire');
+
+    // Test with throwOnFailedInitialization = false
+    td.replace(applicationLogger, 'error');
+    const client = offlinePrecomputedInit({
+      precomputedConfiguration: '',
+      throwOnFailedInitialization: false,
+    });
+
+    expect(client).toBe(EppoPrecomputedJSClient.instance);
+    td.verify(applicationLogger.error('[Eppo SDK] Invalid precomputed configuration wire'), {
+      times: 1,
+    });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -667,15 +667,17 @@ export function offlinePrecomputedInit(
 ): EppoPrecomputedClient {
   const throwOnFailedInitialization = config.throwOnFailedInitialization ?? true;
 
-  const configurationWire: IConfigurationWire = JSON.parse(config.precomputedConfiguration);
-  if (!configurationWire.precomputed) {
+  let configurationWire: IConfigurationWire;
+  try {
+    configurationWire = JSON.parse(config.precomputedConfiguration);
+    if (!configurationWire.precomputed) throw new Error();
+  } catch (error) {
     const errorMessage = 'Invalid precomputed configuration wire';
     if (throwOnFailedInitialization) {
       throw new Error(errorMessage);
-    } else {
-      applicationLogger.error('[Eppo SDK] ${errorMessage}');
-      return EppoPrecomputedJSClient.instance;
     }
+    applicationLogger.error(`[Eppo SDK] ${errorMessage}`);
+    return EppoPrecomputedJSClient.instance;
   }
   const { subjectKey, subjectAttributes, response } = configurationWire.precomputed;
   const parsedResponse: IObfuscatedPrecomputedConfigurationResponse = JSON.parse(response);


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

## Description
[//]: # (Describe your changes in detail)

We noticed an uncaught exception when `precomputedConfiguration` is an empty string. To be consistent with the online `precomputedInit`, this function should also always return an instance if `throwOnFailedInitialization` is `false`

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
