### PR TITLE
add memory-only bandit configuration store for offline client.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "3.9.4-alpha.4",
+  "version": "3.9.4-alpha.5",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [

--- a/src/configuration-factory.ts
+++ b/src/configuration-factory.ts
@@ -6,6 +6,7 @@ import {
   MemoryStore,
   PrecomputedFlag,
 } from '@eppo/js-client-sdk-common';
+import { IObfuscatedPrecomputedBandit } from '@eppo/js-client-sdk-common/dist/interfaces';
 
 import ChromeStorageAsyncMap from './cache/chrome-storage-async-map';
 import { ChromeStorageEngine } from './chrome-storage-engine';
@@ -17,6 +18,10 @@ import { LocalStorageEngine } from './local-storage-engine';
 import { StringValuedAsyncStore } from './string-valued.store';
 
 export function precomputedFlagsStorageFactory(): IConfigurationStore<PrecomputedFlag> {
+  return new MemoryOnlyConfigurationStore();
+}
+
+export function precomputedBanditStoreFactory(): IConfigurationStore<IObfuscatedPrecomputedBandit> {
   return new MemoryOnlyConfigurationStore();
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,7 @@ import {
   hasChromeStorage,
   hasWindowLocalStorage,
   localStorageIfAvailable,
+  precomputedBanditStoreFactory,
 } from './configuration-factory';
 import BrowserNetworkStatusListener from './events/browser-network-status-listener';
 import LocalStorageBackedNamedEventQueue from './events/local-storage-backed-named-event-queue';
@@ -721,6 +722,13 @@ export function offlinePrecomputedInit(
       );
     memoryOnlyPrecomputedStore.salt = parsedResponse.salt;
 
+    const memoryOnlyPrecomputedBanditStore = precomputedBanditStoreFactory();
+    memoryOnlyPrecomputedBanditStore
+      .setEntries(parsedResponse.bandits)
+      .catch((err) =>
+        applicationLogger.warn('Error setting precomputed bandits for memory-only store', err),
+      );
+
     const subject: Subject = {
       subjectKey,
       subjectAttributes: subjectAttributes ?? {},
@@ -729,6 +737,7 @@ export function offlinePrecomputedInit(
     shutdownEppoPrecomputedClient();
     EppoPrecomputedJSClient.instance = new EppoPrecomputedJSClient({
       precomputedFlagStore: memoryOnlyPrecomputedStore,
+      precomputedBanditStore: memoryOnlyPrecomputedBanditStore,
       subject,
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -728,6 +728,7 @@ export function offlinePrecomputedInit(
       .catch((err) =>
         applicationLogger.warn('Error setting precomputed bandits for memory-only store', err),
       );
+    memoryOnlyPrecomputedBanditStore.salt = parsedResponse.salt;
 
     const subject: Subject = {
       subjectKey,


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Initializing bandit store for the offline init.

## Description
[//]: # (Describe your changes in detail)

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
