### PR TITLE
fix: getprecomputedinstance should always return an instance

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -36,6 +36,7 @@ import {
   EppoPrecomputedJSClient,
   getConfigUrl,
   getInstance,
+  getPrecomputedInstance,
   IAssignmentLogger,
   init,
   offlineInit,
@@ -1275,6 +1276,19 @@ describe('offlinePrecomputedInit', () => {
         lifetimeValue: 543.21,
         platform: 'ios',
       },
+    });
+  });
+
+  describe('getPrecomputedInstance', () => {
+    it('returns an instance that safely returns defaults without logging', () => {
+      const mockLogger = td.object<IAssignmentLogger>();
+      const instance = getPrecomputedInstance();
+      instance.setAssignmentLogger(mockLogger);
+
+      const result = instance.getStringAssignment('any-flag', 'default-value');
+
+      expect(result).toBe('default-value');
+      td.verify(mockLogger.logAssignment(td.matchers.anything()), { times: 0 });
     });
   });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -556,7 +556,13 @@ export function getConfigUrl(apiKey: string, baseUrl?: string): URL {
  * @public
  */
 export class EppoPrecomputedJSClient extends EppoPrecomputedClient {
-  public static instance: EppoPrecomputedJSClient;
+  public static instance = new EppoPrecomputedJSClient({
+    precomputedFlagStore: memoryOnlyPrecomputedFlagsStore,
+    subject: {
+      subjectKey: '',
+      subjectAttributes: {},
+    },
+  });
   public static initialized = false;
 
   public getStringAssignment(flagKey: string, defaultValue: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -768,7 +768,7 @@ export function offlinePrecomputedInit(
 }
 
 function shutdownEppoPrecomputedClient() {
-  if (EppoPrecomputedJSClient.instance && EppoPrecomputedJSClient.initialized) {
+  if (EppoPrecomputedJSClient.initialized) {
     EppoPrecomputedJSClient.instance.stopPolling();
     EppoPrecomputedJSClient.initialized = false;
     applicationLogger.warn('[Eppo SDK] Precomputed client is being re-initialized.');

--- a/src/index.ts
+++ b/src/index.ts
@@ -614,7 +614,7 @@ export class EppoPrecomputedJSClient extends EppoPrecomputedClient {
 export async function precomputedInit(
   config: IPrecomputedClientConfig,
 ): Promise<EppoPrecomputedClient> {
-  if (EppoPrecomputedJSClient.instance) {
+  if (EppoPrecomputedJSClient.initialized) {
     return EppoPrecomputedJSClient.instance;
   }
 


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Some feedback [in a previous PR](https://github.com/Eppo-exp/js-sdk-common/pull/164#discussion_r1905896857) that we should avoid overwriting the Eppo client instance.

> We shall prefer creating a new instance of the client in initialization instead of resetting the existing one.

This is challenging because it breaks the expected behavior that `getPrecomputedInstance` always returns an instance of `EppoPrecomputedClient`.

https://github.com/Eppo-exp/js-client-sdk/blob/f5d4eb4c9ccf1475bee47f79ee5900a3a18cddee/src/index.ts#L784-L786

It would be `undefined` before any of the initialization functions (`precomputedInit` or `offlinePrecomputedInit`) are called. This is likely to happen in complex applications with race conditions between various rendering components. This means the code would need an extra protection that the singleton client is defined before calling `client.getStringAssignment(..., defaultValue)`, and this is poor DX because they can't simply rely on the function falling back on returning the `defaultValue` if called before initialization and need to write in their own extra protection.

## Description
[//]: # (Describe your changes in detail)

This initializes the client with an instance with an empty precomputed config store.

So instead of doing

``` javascript
const eppoPrecomputedClient = getPrecomputedInstance();
const precomputedAssignment = eppoPrecomputedClient ? eppoPrecomputedClient.getStringAssignment(flagKey, defaultValue) : defaultValue;
```

you can just do

``` javascript
const eppoPrecomputedClient = getPrecomputedInstance();
const precomputedAssignment = eppoPrecomputedClient.getStringAssignment(flagKey, defaultValue);
```

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
