### PR TITLE
Sameeran/ff 3830 bandits in precomputed init js client sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "3.9.4",
+  "version": "3.9.5",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [

--- a/src/i-client-config.ts
+++ b/src/i-client-config.ts
@@ -1,11 +1,12 @@
 import {
-  AttributeType,
+  BanditSubjectAttributes,
+  ContextAttributes,
   Flag,
   IAssignmentLogger,
   IAsyncStore,
   IBanditLogger,
-  BanditActions,
 } from '@eppo/js-client-sdk-common';
+import type { FlagKey } from '@eppo/js-client-sdk-common/dist/types';
 
 import { ServingStoreUpdateStrategy } from './isolatable-hybrid.store';
 
@@ -86,12 +87,12 @@ interface IPrecompute {
   /**
    * Subject attributes to use for precomputed flag assignments.
    */
-  subjectAttributes?: Record<string, AttributeType>;
+  subjectAttributes?: BanditSubjectAttributes;
 
   /**
    * Bandit actions to use for precomputed flag assignments.
    */
-  banditActions?: BanditActions;
+  banditActions?: Record<FlagKey, Record<string /*banditAction name*/, ContextAttributes>>;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -624,7 +624,7 @@ export async function precomputedInit(
 
   const {
     apiKey,
-    precompute: { subjectKey, subjectAttributes = {} },
+    precompute: { subjectKey, subjectAttributes = {}, banditActions },
     baseUrl,
     requestTimeoutMs,
     numInitialRequestRetries,
@@ -658,6 +658,7 @@ export async function precomputedInit(
     requestParameters,
     subject,
     precomputedBanditStore: memoryOnlyPrecomputedBanditsStore,
+    banditActions,
   });
 
   EppoPrecomputedJSClient.instance.setAssignmentLogger(config.assignmentLogger);


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

We need to include `banditActions` when instantiating the precomputed client if using it for bandits.

## Description
[//]: # (Describe your changes in detail)

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
