### PR TITLE
fix: use repo and ref parameters in checkout action

### DIFF
--- a/.github/workflows/lint-test-sdk.yml
+++ b/.github/workflows/lint-test-sdk.yml
@@ -35,6 +35,9 @@ jobs:
           echo "Test Data: sdk-test-data@${TEST_DATA_BRANCH_NAME}"
           echo "SDK Branch: js-client-sdk@${SDK_BRANCH_NAME}"
       - uses: actions/checkout@v3
+        with:
+          repository: Eppo-exp/js-client-sdk
+          ref: ${{ env.SDK_BRANCH_NAME }}
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
@@ -65,6 +68,9 @@ jobs:
         node-version: [ '18', '20', '22', '23' ]
     steps:
       - uses: actions/checkout@v3
+        with:
+          repository: Eppo-exp/js-client-sdk
+          ref: ${{ env.SDK_BRANCH_NAME }}
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
_Eppo Internal_
🎟️ 
Fixes: [FF-3866](https://linear.app/eppo/issue/FF-3866/js-client-tests-are-failing-when-run-in-sdk-test-data)

## Motivation and Context
The testing workflow is reused remotely in the *sdk-test-data* repository. To make these workflows reusable, the repository and branch must be specified for the checkout action otherwise, the default of `sdk-test-data` will be used (since the action runs in the sdk-test-data repository)

## Description
- reintroduce the parameters that were dropped in #101 

## How has this been tested?
- Triggered the tests from the sdk-test-data repo.
https://github.com/Eppo-exp/sdk-test-data/actions/runs/12938159310/job/36087690316
