### PR TITLE
feat: assignment cache to dedupe logging by the precomputed client

### DIFF
--- a/docs/js-client-sdk.init.md
+++ b/docs/js-client-sdk.init.md
@@ -4,7 +4,7 @@
 
 ## init() function
 
-Initializes the Eppo client with configuration parameters. This method should be called once on application startup.
+Initializes the Eppo client with configuration parameters. This method should be called once on application startup. If an initialization is in process, calling `init` will return the in-progress `Promise<EppoClient>`<!-- -->. Once the initialization completes, calling `init` again will kick off the initialization routine (if `forceReinitialization` is `true`<!-- -->).
 
 **Signature:**
 

--- a/docs/js-client-sdk.md
+++ b/docs/js-client-sdk.md
@@ -120,7 +120,7 @@ Used to access a singleton SDK precomputed client instance. Use the method after
 
 </td><td>
 
-Initializes the Eppo client with configuration parameters. This method should be called once on application startup.
+Initializes the Eppo client with configuration parameters. This method should be called once on application startup. If an initialization is in process, calling `init` will return the in-progress `Promise<EppoClient>`<!-- -->. Once the initialization completes, calling `init` again will kick off the initialization routine (if `forceReinitialization` is `true`<!-- -->).
 
 
 </td></tr>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "3.9.7",
+  "version": "3.9.8",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1316,10 +1316,7 @@ describe('EppoPrecomputedJSClient E2E test', () => {
   it('deduplicates assignment logging', () => {
     // Reset the mock logger and assignment cache before this test
     const mockLogger = td.object<IAssignmentLogger>();
-    const mockAssignmentCache = td.object<AssignmentCache>();
-    td.when(mockAssignmentCache.has(td.matchers.anything())).thenReturn(false, true);
-    td.when(mockAssignmentCache.set(td.matchers.anything())).thenReturn();
-    globalClient.useCustomAssignmentCache(mockAssignmentCache);
+    globalClient.useNonExpiringInMemoryAssignmentCache();
     globalClient.setAssignmentLogger(mockLogger);
 
     expect(td.explain(mockLogger.logAssignment).callCount).toEqual(0);

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1419,6 +1419,22 @@ describe('offlinePrecomputedInit', () => {
       { times: 1 },
     );
   });
+
+  it('deduplicates assignment logging', () => {
+    const client = offlinePrecomputedInit({
+      precomputedConfiguration,
+      assignmentLogger: mockLogger,
+    });
+    expect(td.explain(mockLogger.logAssignment).callCount).toBe(0);
+    client.getStringAssignment('string-flag', 'default');
+    expect(td.explain(mockLogger.logAssignment).callCount).toBe(1);
+    client.getStringAssignment('string-flag', 'default');
+    expect(td.explain(mockLogger.logAssignment).callCount).toBe(1);
+    expect(td.explain(mockLogger.logAssignment).calls[0]?.args[0]).toMatchObject({
+      subject: 'test-subject-key',
+      featureFlag: 'string-flag',
+    });
+  });
 });
 
 describe('EppoClient config', () => {


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

The precompute client needs the assignment cache to dedupe assignments. This is central functionality of the SDKs, not a nice-to-have

## Description
[//]: # (Describe your changes in detail)

Scope of work:

- [x] offline init - use in-memory assignment cache
- [x] online init - use hybrid assignment cache

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
