### PR TITLE
fix: don't fallback to default value in test harness

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -358,7 +358,7 @@ describe('EppoJSClient E2E test', () => {
         const client = getInstance();
 
         const typeAssignmentFunctions = {
-          [VariationType.BOOLEAN]: client.getBoolAssignment.bind(client),
+          [VariationType.BOOLEAN]: client.getBooleanAssignment.bind(client),
           [VariationType.NUMERIC]: client.getNumericAssignment.bind(client),
           [VariationType.INTEGER]: client.getIntegerAssignment.bind(client),
           [VariationType.STRING]: client.getStringAssignment.bind(client),

--- a/test/testHelpers.ts
+++ b/test/testHelpers.ts
@@ -90,14 +90,13 @@ export function getTestAssignments(
     assignment: string | boolean | number | object;
   }[] = [];
   for (const subject of testCase.subjects) {
-    const assignment =
-      assignmentFn(
-        testCase.flag,
-        subject.subjectKey,
-        subject.subjectAttributes,
-        testCase.defaultValue,
-        obfuscated,
-      ) || testCase.defaultValue; // Fallback to defaultValue if null
+    const assignment = assignmentFn(
+      testCase.flag,
+      subject.subjectKey,
+      subject.subjectAttributes,
+      testCase.defaultValue,
+      obfuscated,
+    );
     assignments.push({ subject: subject, assignment: assignment });
   }
   return assignments;


### PR DESCRIPTION
## Motivation and Context
The js-client UFC tests are failing when an expected assignment is the empty string. Upon investigation, this is failing because of a well intentioned check of the assignment result. This check fails when the assignment is an empty string (and likely when the assignment is intentionally false but we haven't test cases to cover this).
Ultimately, the bug lies in the testing harness, not the core code, as the node server and js-common SDKs do not fail in this manner.

## Description
- remove the truthy check; don't fallback on default value as the EppoClient handles that.
- update to use `getBoolean` instead of deprecated `getBool`
