### PR TITLE
chore: move initialization into class methods, limit singleton use

### DIFF
--- a/docs/js-client-sdk.eppojsclient.initialized.md
+++ b/docs/js-client-sdk.eppojsclient.initialized.md
@@ -4,6 +4,10 @@
 
 ## EppoJSClient.initialized property
 
+> Warning: This API is now obsolete.
+> 
+> 
+
 **Signature:**
 
 ```typescript

--- a/docs/js-client-sdk.eppojsclient.initialized.md
+++ b/docs/js-client-sdk.eppojsclient.initialized.md
@@ -4,10 +4,6 @@
 
 ## EppoJSClient.initialized property
 
-> Warning: This API is now obsolete.
-> 
-> 
-
 **Signature:**
 
 ```typescript

--- a/docs/js-client-sdk.eppojsclient.instance.md
+++ b/docs/js-client-sdk.eppojsclient.instance.md
@@ -4,6 +4,8 @@
 
 ## EppoJSClient.instance property
 
+@<!-- -->deprecated. use `getInstance()` instead.
+
 **Signature:**
 
 ```typescript

--- a/docs/js-client-sdk.eppojsclient.md
+++ b/docs/js-client-sdk.eppojsclient.md
@@ -72,6 +72,8 @@ boolean
 
 </td><td>
 
+@<!-- -->deprecated. use `getInstance()` instead.
+
 
 </td></tr>
 </tbody></table>

--- a/docs/js-client-sdk.getinstance.md
+++ b/docs/js-client-sdk.getinstance.md
@@ -9,11 +9,11 @@ Used to access a singleton SDK client instance. Use the method after calling ini
 **Signature:**
 
 ```typescript
-export declare function getInstance(): EppoClient;
+export declare function getInstance(): EppoJSClient;
 ```
 **Returns:**
 
-EppoClient
+[EppoJSClient](./js-client-sdk.eppojsclient.md)
 
 a singleton client instance
 

--- a/docs/js-client-sdk.init.md
+++ b/docs/js-client-sdk.init.md
@@ -4,12 +4,12 @@
 
 ## init() function
 
-Initializes the Eppo client with configuration parameters. This method should be called once on application startup. If an initialization is in process, calling `init` will return the in-progress `Promise<EppoClient>`<!-- -->. Once the initialization completes, calling `init` again will kick off the initialization routine (if `forceReinitialization` is `true`<!-- -->).
+Initializes the Eppo client with configuration parameters. This method should be called once on application startup.
 
 **Signature:**
 
 ```typescript
-export declare function init(config: IClientConfig): Promise<EppoClient>;
+export declare function init(config: IClientConfig): Promise<EppoJSClient>;
 ```
 
 ## Parameters
@@ -49,5 +49,5 @@ client configuration
 </tbody></table>
 **Returns:**
 
-Promise&lt;EppoClient&gt;
+Promise&lt;[EppoJSClient](./js-client-sdk.eppojsclient.md)<!-- -->&gt;
 

--- a/docs/js-client-sdk.init.md
+++ b/docs/js-client-sdk.init.md
@@ -4,7 +4,7 @@
 
 ## init() function
 
-Initializes the Eppo client with configuration parameters. This method should be called once on application startup.
+Initializes the Eppo client with configuration parameters. This method should be called once on application startup. If an initialization is in process, calling `init` will return the in-progress `Promise<EppoClient>`<!-- -->. Once the initialization completes, calling `init` again will kick off the initialization routine (if `forceReinitialization` is `true`<!-- -->).
 
 **Signature:**
 

--- a/docs/js-client-sdk.init.md
+++ b/docs/js-client-sdk.init.md
@@ -4,7 +4,7 @@
 
 ## init() function
 
-Initializes the Eppo client with configuration parameters. This method should be called once on application startup. If an initialization is in process, calling `init` will return the in-progress `Promise<EppoClient>`<!-- -->. Once the initialization completes, calling `init` again will kick off the initialization routine (if `forceReinitialization` is `true`<!-- -->).
+Initializes the Eppo client with configuration parameters. This method should be called once on application startup.
 
 **Signature:**
 

--- a/docs/js-client-sdk.md
+++ b/docs/js-client-sdk.md
@@ -120,7 +120,7 @@ Used to access a singleton SDK precomputed client instance. Use the method after
 
 </td><td>
 
-Initializes the Eppo client with configuration parameters. This method should be called once on application startup. If an initialization is in process, calling `init` will return the in-progress `Promise<EppoClient>`<!-- -->. Once the initialization completes, calling `init` again will kick off the initialization routine (if `forceReinitialization` is `true`<!-- -->).
+Initializes the Eppo client with configuration parameters. This method should be called once on application startup.
 
 
 </td></tr>

--- a/docs/js-client-sdk.md
+++ b/docs/js-client-sdk.md
@@ -120,7 +120,7 @@ Used to access a singleton SDK precomputed client instance. Use the method after
 
 </td><td>
 
-Initializes the Eppo client with configuration parameters. This method should be called once on application startup.
+Initializes the Eppo client with configuration parameters. This method should be called once on application startup. If an initialization is in process, calling `init` will return the in-progress `Promise<EppoClient>`<!-- -->. Once the initialization completes, calling `init` again will kick off the initialization routine (if `forceReinitialization` is `true`<!-- -->).
 
 
 </td></tr>

--- a/js-client-sdk.api.md
+++ b/js-client-sdk.api.md
@@ -84,10 +84,13 @@ export class EppoJSClient extends EppoClient {
     getStringAssignment(flagKey: string, subjectKey: string, subjectAttributes: Record<string, AttributeType>, defaultValue: string): string;
     // (undocumented)
     getStringAssignmentDetails(flagKey: string, subjectKey: string, subjectAttributes: Record<string, AttributeType>, defaultValue: string): IAssignmentDetails<string>;
-    // (undocumented)
+    // @internal (undocumented)
+    init(config: Omit<IClientConfig, 'forceReinitialize'>): Promise<EppoJSClient>;
+    // @deprecated (undocumented)
     static initialized: boolean;
-    // (undocumented)
     static instance: EppoJSClient;
+    // @internal (undocumented)
+    offlineInit(config: IClientConfigSync): void;
 }
 
 // @public
@@ -116,7 +119,7 @@ export { Flag }
 export function getConfigUrl(apiKey: string, baseUrl?: string): URL;
 
 // @public
-export function getInstance(): EppoClient;
+export function getInstance(): EppoJSClient;
 
 // @public
 export function getPrecomputedInstance(): EppoPrecomputedClient;
@@ -169,7 +172,7 @@ export interface IClientConfigSync {
 }
 
 // @public
-export function init(config: IClientConfig): Promise<EppoClient>;
+export function init(config: IClientConfig): Promise<EppoJSClient>;
 
 // @public
 export interface IPrecomputedClientConfig extends IBaseRequestConfig {

--- a/js-client-sdk.api.md
+++ b/js-client-sdk.api.md
@@ -86,7 +86,7 @@ export class EppoJSClient extends EppoClient {
     getStringAssignmentDetails(flagKey: string, subjectKey: string, subjectAttributes: Record<string, AttributeType>, defaultValue: string): IAssignmentDetails<string>;
     // @internal (undocumented)
     init(config: Omit<IClientConfig, 'forceReinitialize'>): Promise<EppoJSClient>;
-    // @deprecated (undocumented)
+    // (undocumented)
     static initialized: boolean;
     static instance: EppoJSClient;
     // @internal (undocumented)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "3.9.7",
+  "version": "3.10.0",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,9 +109,6 @@ export class EppoJSClient extends EppoClient {
     isObfuscated: true,
   });
 
-  /**
-   * @deprecated
-   */
   public static initialized = false;
 
   private initialized = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -271,6 +271,12 @@ export class EppoJSClient extends EppoClient {
     }
   }
 
+  /**
+   * Initialize the Eppo Client.
+   *
+   * @internal
+   * @param config
+   */
   async init(config: IClientConfig): Promise<EppoJSClient> {
     validation.validateNotBlank(config.apiKey, 'API key required');
     let initializationError: Error | undefined;
@@ -495,6 +501,12 @@ export class EppoJSClient extends EppoClient {
     return this;
   }
 
+  /**
+   * Initialize the client synchronously, for offline use.
+   *
+   * @internal
+   * @param config
+   */
   offlineInit(config: IClientConfigSync) {
     const isObfuscated = config.isObfuscated ?? false;
     const throwOnFailedInitialization = config.throwOnFailedInitialization ?? true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,10 +272,7 @@ export class EppoJSClient extends EppoClient {
   }
 
   /**
-   * Initialize the Eppo Client.
-   *
    * @internal
-   * @param config
    */
   async init(config: IClientConfig): Promise<EppoJSClient> {
     validation.validateNotBlank(config.apiKey, 'API key required');
@@ -502,10 +499,7 @@ export class EppoJSClient extends EppoClient {
   }
 
   /**
-   * Initialize the client synchronously, for offline use.
-   *
    * @internal
-   * @param config
    */
   offlineInit(config: IClientConfigSync) {
     const isObfuscated = config.isObfuscated ?? false;
@@ -589,6 +583,7 @@ export function offlineInit(config: IClientConfigSync): EppoClient {
 
   // For backwards compatibility.
   EppoJSClient.initialized = true;
+
   return instance;
 }
 
@@ -619,6 +614,7 @@ export async function init(config: IClientConfig): Promise<EppoJSClient> {
 
   // For backwards compatibility.
   EppoJSClient.initialized = true;
+
   return client;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -101,11 +101,20 @@ export class EppoJSClient extends EppoClient {
   // Ensure that the client is instantiated during class loading.
   // Use an empty memory-only configuration store until the `init` method is called,
   // to avoid serving stale data to the user.
+  /**
+   * @deprecated. use `getInstance()` instead.
+   */
   public static instance = new EppoJSClient({
     flagConfigurationStore,
     isObfuscated: true,
   });
+
+  /**
+   * @deprecated
+   */
   public static initialized = false;
+
+  private initialized = false;
 
   public getStringAssignment(
     flagKey: string,
@@ -113,7 +122,7 @@ export class EppoJSClient extends EppoClient {
     subjectAttributes: Record<string, AttributeType>,
     defaultValue: string,
   ): string {
-    EppoJSClient.ensureInitialized();
+    this.ensureInitialized();
     return super.getStringAssignment(flagKey, subjectKey, subjectAttributes, defaultValue);
   }
 
@@ -123,7 +132,7 @@ export class EppoJSClient extends EppoClient {
     subjectAttributes: Record<string, AttributeType>,
     defaultValue: string,
   ): IAssignmentDetails<string> {
-    EppoJSClient.ensureInitialized();
+    this.ensureInitialized();
     return super.getStringAssignmentDetails(flagKey, subjectKey, subjectAttributes, defaultValue);
   }
 
@@ -145,7 +154,7 @@ export class EppoJSClient extends EppoClient {
     subjectAttributes: Record<string, AttributeType>,
     defaultValue: boolean,
   ): boolean {
-    EppoJSClient.ensureInitialized();
+    this.ensureInitialized();
     return super.getBooleanAssignment(flagKey, subjectKey, subjectAttributes, defaultValue);
   }
 
@@ -155,7 +164,7 @@ export class EppoJSClient extends EppoClient {
     subjectAttributes: Record<string, AttributeType>,
     defaultValue: boolean,
   ): IAssignmentDetails<boolean> {
-    EppoJSClient.ensureInitialized();
+    this.ensureInitialized();
     return super.getBooleanAssignmentDetails(flagKey, subjectKey, subjectAttributes, defaultValue);
   }
 
@@ -165,7 +174,7 @@ export class EppoJSClient extends EppoClient {
     subjectAttributes: Record<string, AttributeType>,
     defaultValue: number,
   ): number {
-    EppoJSClient.ensureInitialized();
+    this.ensureInitialized();
     return super.getIntegerAssignment(flagKey, subjectKey, subjectAttributes, defaultValue);
   }
 
@@ -175,7 +184,7 @@ export class EppoJSClient extends EppoClient {
     subjectAttributes: Record<string, AttributeType>,
     defaultValue: number,
   ): IAssignmentDetails<number> {
-    EppoJSClient.ensureInitialized();
+    this.ensureInitialized();
     return super.getIntegerAssignmentDetails(flagKey, subjectKey, subjectAttributes, defaultValue);
   }
 
@@ -185,7 +194,7 @@ export class EppoJSClient extends EppoClient {
     subjectAttributes: Record<string, AttributeType>,
     defaultValue: number,
   ): number {
-    EppoJSClient.ensureInitialized();
+    this.ensureInitialized();
     return super.getNumericAssignment(flagKey, subjectKey, subjectAttributes, defaultValue);
   }
 
@@ -195,7 +204,7 @@ export class EppoJSClient extends EppoClient {
     subjectAttributes: Record<string, AttributeType>,
     defaultValue: number,
   ): IAssignmentDetails<number> {
-    EppoJSClient.ensureInitialized();
+    this.ensureInitialized();
     return super.getNumericAssignmentDetails(flagKey, subjectKey, subjectAttributes, defaultValue);
   }
 
@@ -205,7 +214,7 @@ export class EppoJSClient extends EppoClient {
     subjectAttributes: Record<string, AttributeType>,
     defaultValue: object,
   ): object {
-    EppoJSClient.ensureInitialized();
+    this.ensureInitialized();
     return super.getJSONAssignment(flagKey, subjectKey, subjectAttributes, defaultValue);
   }
 
@@ -215,7 +224,7 @@ export class EppoJSClient extends EppoClient {
     subjectAttributes: Record<string, AttributeType>,
     defaultValue: object,
   ): IAssignmentDetails<object> {
-    EppoJSClient.ensureInitialized();
+    this.ensureInitialized();
     return super.getJSONAssignmentDetails(flagKey, subjectKey, subjectAttributes, defaultValue);
   }
 
@@ -226,7 +235,7 @@ export class EppoJSClient extends EppoClient {
     actions: BanditActions,
     defaultValue: string,
   ): Omit<IAssignmentDetails<string>, 'evaluationDetails'> {
-    EppoJSClient.ensureInitialized();
+    this.ensureInitialized();
     return super.getBanditAction(flagKey, subjectKey, subjectAttributes, actions, defaultValue);
   }
 
@@ -237,7 +246,7 @@ export class EppoJSClient extends EppoClient {
     actions: BanditActions,
     defaultValue: string,
   ): IAssignmentDetails<string> {
-    EppoJSClient.ensureInitialized();
+    this.ensureInitialized();
     return super.getBanditActionDetails(
       flagKey,
       subjectKey,
@@ -252,14 +261,290 @@ export class EppoJSClient extends EppoClient {
     subjectKey: string,
     subjectAttributes: Record<string, AttributeType>,
   ): T {
-    EppoJSClient.ensureInitialized();
+    this.ensureInitialized();
     return super.getExperimentContainerEntry(flagExperiment, subjectKey, subjectAttributes);
   }
 
-  private static ensureInitialized() {
-    if (!EppoJSClient.initialized) {
+  private ensureInitialized() {
+    if (!this.initialized) {
       applicationLogger.warn('Eppo SDK assignment requested before init() completed');
     }
+  }
+
+  async init(config: IClientConfig): Promise<EppoJSClient> {
+    validation.validateNotBlank(config.apiKey, 'API key required');
+    let initializationError: Error | undefined;
+
+    const {
+      apiKey,
+      persistentStore,
+      baseUrl,
+      maxCacheAgeSeconds,
+      updateOnFetch,
+      forceReinitialize,
+      requestTimeoutMs,
+      numInitialRequestRetries,
+      numPollRequestRetries,
+      pollingIntervalMs,
+      pollAfterSuccessfulInitialization = false,
+      pollAfterFailedInitialization = false,
+      skipInitialRequest = false,
+      eventIngestionConfig,
+    } = config;
+    try {
+      if (this.initialized) {
+        if (forceReinitialize) {
+          applicationLogger.warn(
+            'Eppo SDK is already initialized, reinitializing since forceReinitialize is true.',
+          );
+          this.initialized = false;
+        } else {
+          applicationLogger.warn(
+            'Eppo SDK is already initialized, skipping reinitialization since forceReinitialize is false.',
+          );
+          return this;
+        }
+      }
+
+      // If any existing instances; ensure they are not polling
+      this.stopPolling();
+      // Set up assignment logger and cache
+      this.setAssignmentLogger(config.assignmentLogger);
+      if (config.banditLogger) {
+        this.setBanditLogger(config.banditLogger);
+      }
+      // Default to obfuscated mode when requesting configuration from the server.
+      this.setIsObfuscated(true);
+
+      const storageKeySuffix = buildStorageKeySuffix(apiKey);
+
+      // Set the configuration store to the desired persistent store, if provided.
+      // Otherwise, the factory method will detect the current environment and instantiate the correct store.
+      const configurationStore = configurationStorageFactory(
+        {
+          maxAgeSeconds: maxCacheAgeSeconds,
+          servingStoreUpdateStrategy: updateOnFetch,
+          persistentStore,
+          hasChromeStorage: hasChromeStorage(),
+          hasWindowLocalStorage: hasWindowLocalStorage(),
+        },
+        {
+          chromeStorage: chromeStorageIfAvailable(),
+          windowLocalStorage: localStorageIfAvailable(),
+          storageKeySuffix,
+        },
+      );
+      this.setFlagConfigurationStore(configurationStore);
+
+      // instantiate and init assignment cache
+      const assignmentCache = assignmentCacheFactory({
+        chromeStorage: chromeStorageIfAvailable(),
+        storageKeySuffix,
+      });
+      if (assignmentCache instanceof HybridAssignmentCache) {
+        await assignmentCache.init();
+      }
+      this.useCustomAssignmentCache(assignmentCache);
+
+      // Set up parameters for requesting updated configurations
+      const requestConfiguration: FlagConfigurationRequestParameters = {
+        apiKey,
+        sdkName,
+        sdkVersion,
+        baseUrl,
+        requestTimeoutMs,
+        numInitialRequestRetries,
+        numPollRequestRetries,
+        pollAfterSuccessfulInitialization,
+        pollAfterFailedInitialization,
+        pollingIntervalMs,
+        throwOnFailedInitialization: true, // always use true here as underlying instance fetch is surrounded by try/catch
+        skipInitialPoll: skipInitialRequest,
+      };
+      this.setConfigurationRequestParameters(requestConfiguration);
+      this.setEventDispatcher(newEventDispatcher(apiKey, eventIngestionConfig));
+
+      // We have two at-bats for initialization: from the configuration store and from fetching
+      // We can resolve the initialization promise as soon as either one succeeds
+      // If there is no persistent store underlying the ConfigurationStore, then there is no race to begin with, as
+      // there is not an async local load to wait for.
+
+      // The definition of a successful configuration load differs for a cached config vs a fetched config.
+      // Specifically, a cached config with no entries is not considered a completed load and will result in
+      // `ConfigLoaderStatus.DID_NOT_PRODUCE` while and empty config from the fetch is considered a valid, `COMPLETED`
+      //  configuration load.
+      let initFromConfigStoreError = undefined;
+      let initFromFetchError = undefined;
+
+      const attemptInitFromConfigStore: ConfigurationLoadAttempt = configurationStore
+        .init()
+        .then(async () => {
+          if (!configurationStore.getKeys().length) {
+            // Consider empty configuration stores invalid
+            applicationLogger.warn('Eppo SDK cached configuration is empty');
+            initFromConfigStoreError = new Error('Configuration store was empty');
+            return ConfigLoaderStatus.DID_NOT_PRODUCE;
+          }
+
+          const cacheIsExpired = await configurationStore.isExpired();
+          if (cacheIsExpired && !config.useExpiredCache) {
+            applicationLogger.warn('Eppo SDK set not to use expired cached configuration');
+            initFromConfigStoreError = new Error('Configuration store was expired');
+            return ConfigLoaderStatus.DID_NOT_PRODUCE;
+          } else if (cacheIsExpired && config.useExpiredCache) {
+            applicationLogger.warn('Eppo SDK config.useExpiredCache is true; using expired cache');
+          }
+
+          return ConfigLoaderStatus.COMPLETED;
+        })
+        .catch((e) => {
+          applicationLogger.warn(
+            'Eppo SDK encountered an error initializing from the configuration store',
+            e,
+          );
+          initFromConfigStoreError = e;
+          return ConfigLoaderStatus.FAILED;
+        })
+        .then((status) => {
+          return { source: ConfigSource.CONFIG_STORE, result: status };
+        });
+
+      // Kick off a remote fetch (and start the poller, if configured to do so).
+      // Before a network fetch is attempted, the `ConfiguratonRequestor` instance will check to see whether the
+      // locally-stored config data is expired. If it is not expired, the network fetch is skipped, and the promise chain
+      // will quickly return. **When data not successfully fetched due to an error, invalid data, or giving up the fetch
+      // because the cache is not expired, the configuration store will not be set as initialized.**
+      const attemptInitFromFetch: ConfigurationLoadAttempt = this.fetchFlagConfigurations()
+        .then(() => {
+          if (configurationStore.isInitialized()) {
+            // If fetch has won the race and the configStore is initialized, that means we have a successful load and the
+            // fetched data was used to init.
+            return ConfigLoaderStatus.COMPLETED;
+          } else {
+            // If the config store is not initialized and the fetch says it is done, that means the fetch did not set any
+            // values into the config store (ex:the cache is not expired or invalid config data was received).
+            // It's important not to set an error here as this state does not mean that an error was encountered.
+            // If the initial cache had not expired, the fetch would be skipped and the config store would report as
+            // uninitialized because only a successful fetch setting the data entries will set the persistent store as
+            // initialized.
+            return ConfigLoaderStatus.DID_NOT_PRODUCE;
+          }
+        })
+        .catch((e) => {
+          applicationLogger.warn('Eppo SDK encountered an error initializing from fetching', e);
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          initFromFetchError = e;
+          return ConfigLoaderStatus.FAILED;
+        })
+        .then((status) => {
+          return { source: ConfigSource.FETCH, result: status };
+        });
+
+      const racers: ConfigurationLoadAttempt[] = [attemptInitFromConfigStore];
+
+      // attemptInitFromFetch will return early and not attempt to fetch if `skipInitialRequest` is `true`.
+      // We could still race it against a load from configuration as the handling logic will see that no config was loaded
+      // into the config store from the remote fetch and return `DID_NOT_PRODUCE`.
+      if (!config.skipInitialRequest) {
+        racers.push(attemptInitFromFetch);
+      }
+      let initializationSource: ConfigSource;
+      const { source: firstSource, result: firstConfigResult } = await Promise.race(racers);
+
+      if (firstConfigResult === ConfigLoaderStatus.COMPLETED) {
+        // First config load successfully produced a configuration
+        initializationSource = firstSource;
+      } else {
+        // First attempt failed or did not produce configuration, but we have a second at bat that will be executed in the scope of the top-level try-catch
+
+        const secondAttempt =
+          firstSource === ConfigSource.FETCH ? attemptInitFromConfigStore : attemptInitFromFetch;
+
+        initializationSource = await secondAttempt.then((resultPair: ConfigLoadResult) => {
+          const { source, result } = resultPair;
+          return result === ConfigLoaderStatus.COMPLETED ? source : ConfigSource.NONE;
+        });
+      }
+
+      if (initializationSource === ConfigSource.NONE) {
+        // Neither config loader produced useful config. Return error, if exists, in order from first to last: fetch, config store, generic.
+        initializationError = initFromFetchError
+          ? initFromFetchError
+          : initFromConfigStoreError
+            ? initFromConfigStoreError
+            : new Error('Eppo SDK: No configuration source produced a valid configuration');
+      }
+      applicationLogger.debug('Initialization source', initializationSource);
+    } catch (error: unknown) {
+      initializationError = error instanceof Error ? error : new Error(String(error));
+    }
+
+    if (initializationError) {
+      applicationLogger.warn(
+        'Eppo SDK was unable to initialize with a configuration, assignment calls will return the default value and not be logged' +
+          (config.pollAfterFailedInitialization
+            ? ' until an experiment configuration is successfully retrieved'
+            : ''),
+      );
+      if (config.throwOnFailedInitialization ?? true) {
+        throw initializationError;
+      }
+    }
+
+    this.initialized = true;
+    return this;
+  }
+
+  offlineInit(config: IClientConfigSync) {
+    const isObfuscated = config.isObfuscated ?? false;
+    const throwOnFailedInitialization = config.throwOnFailedInitialization ?? true;
+
+    try {
+      const memoryOnlyConfigurationStore = configurationStorageFactory({
+        forceMemoryOnly: true,
+      });
+      memoryOnlyConfigurationStore
+        .setEntries(config.flagsConfiguration)
+        .catch((err) =>
+          applicationLogger.warn('Error setting flags for memory-only configuration store', err),
+        );
+      this.setFlagConfigurationStore(memoryOnlyConfigurationStore);
+
+      // Allow the caller to override the default obfuscated mode, which is false
+      // since the purpose of this method is to bootstrap the SDK from an external source,
+      // which is likely a server that has not-obfuscated flag values.
+      this.setIsObfuscated(isObfuscated);
+
+      if (config.assignmentLogger) {
+        this.setAssignmentLogger(config.assignmentLogger);
+      }
+
+      if (config.banditLogger) {
+        this.setBanditLogger(config.banditLogger);
+      }
+
+      // There is no SDK key in the offline context.
+      const storageKeySuffix = 'offline';
+
+      // As this is a synchronous initialization,
+      // we are unable to call the async `init` method on the assignment cache
+      // which loads the assignment cache from the browser's storage.
+      // Therefore, there is no purpose trying to use a persistent assignment cache.
+      const assignmentCache = assignmentCacheFactory({
+        storageKeySuffix,
+        forceMemoryOnly: true,
+      });
+      this.useCustomAssignmentCache(assignmentCache);
+    } catch (error) {
+      applicationLogger.warn(
+        'Eppo SDK encountered an error initializing, assignment calls will return the default value and not be logged',
+      );
+      if (throwOnFailedInitialization) {
+        throw error;
+      }
+    }
+
+    this.initialized = true;
   }
 }
 
@@ -287,308 +572,42 @@ export function buildStorageKeySuffix(apiKey: string): string {
  * @public
  */
 export function offlineInit(config: IClientConfigSync): EppoClient {
-  const isObfuscated = config.isObfuscated ?? false;
-  const throwOnFailedInitialization = config.throwOnFailedInitialization ?? true;
+  const instance = getInstance();
+  instance.offlineInit(config);
 
-  try {
-    const memoryOnlyConfigurationStore = configurationStorageFactory({
-      forceMemoryOnly: true,
-    });
-    memoryOnlyConfigurationStore
-      .setEntries(config.flagsConfiguration)
-      .catch((err) =>
-        applicationLogger.warn('Error setting flags for memory-only configuration store', err),
-      );
-    EppoJSClient.instance.setFlagConfigurationStore(memoryOnlyConfigurationStore);
-
-    // Allow the caller to override the default obfuscated mode, which is false
-    // since the purpose of this method is to bootstrap the SDK from an external source,
-    // which is likely a server that has not-obfuscated flag values.
-    EppoJSClient.instance.setIsObfuscated(isObfuscated);
-
-    if (config.assignmentLogger) {
-      EppoJSClient.instance.setAssignmentLogger(config.assignmentLogger);
-    }
-
-    if (config.banditLogger) {
-      EppoJSClient.instance.setBanditLogger(config.banditLogger);
-    }
-
-    // There is no SDK key in the offline context.
-    const storageKeySuffix = 'offline';
-
-    // As this is a synchronous initialization,
-    // we are unable to call the async `init` method on the assignment cache
-    // which loads the assignment cache from the browser's storage.
-    // Therefore, there is no purpose trying to use a persistent assignment cache.
-    const assignmentCache = assignmentCacheFactory({
-      storageKeySuffix,
-      forceMemoryOnly: true,
-    });
-    EppoJSClient.instance.useCustomAssignmentCache(assignmentCache);
-  } catch (error) {
-    applicationLogger.warn(
-      'Eppo SDK encountered an error initializing, assignment calls will return the default value and not be logged',
-    );
-    if (throwOnFailedInitialization) {
-      throw error;
-    }
-  }
-
+  // For backwards compatibility.
   EppoJSClient.initialized = true;
-  return EppoJSClient.instance;
+  return instance;
 }
 
 /**
- * Tracks pending initialization. After an initialization completes, the value is removed from the map.
+ * Tracks pending initialization. After an initialization completes, the value is set to null.
  */
-let initializationPromise: Promise<EppoClient> | null = null;
+let initializationPromise: Promise<EppoJSClient> | null = null;
 
 /**
  * Initializes the Eppo client with configuration parameters.
  * This method should be called once on application startup.
  * If an initialization is in process, calling `init` will return the in-progress
  * `Promise<EppoClient>`. Once the initialization completes, calling `init` again will kick off the
- * initialization routine (if `forceReinitialization` is `true`).
+ * initialization routine (if `forceReinitialize` is `true`).
  * @param config - client configuration
  * @public
  */
-export async function init(config: IClientConfig): Promise<EppoClient> {
+export async function init(config: IClientConfig): Promise<EppoJSClient> {
   validation.validateNotBlank(config.apiKey, 'API key required');
-
-  // If there is already an init in progress for this apiKey, return that.
+  const instance = getInstance();
+  // If there is already an init in progress, return that.
   if (!initializationPromise) {
-    initializationPromise = explicitInit(config);
+    initializationPromise = instance.init(config);
   }
 
   const client = await initializationPromise;
   initializationPromise = null;
-  return client;
-}
 
-async function explicitInit(config: IClientConfig): Promise<EppoClient> {
-  validation.validateNotBlank(config.apiKey, 'API key required');
-  let initializationError: Error | undefined;
-  const instance = EppoJSClient.instance;
-  const {
-    apiKey,
-    persistentStore,
-    baseUrl,
-    maxCacheAgeSeconds,
-    updateOnFetch,
-    forceReinitialize,
-    requestTimeoutMs,
-    numInitialRequestRetries,
-    numPollRequestRetries,
-    pollingIntervalMs,
-    pollAfterSuccessfulInitialization = false,
-    pollAfterFailedInitialization = false,
-    skipInitialRequest = false,
-    eventIngestionConfig,
-  } = config;
-  try {
-    if (EppoJSClient.initialized) {
-      if (forceReinitialize) {
-        applicationLogger.warn(
-          'Eppo SDK is already initialized, reinitializing since forceReinitialize is true.',
-        );
-        EppoJSClient.initialized = false;
-      } else {
-        applicationLogger.warn(
-          'Eppo SDK is already initialized, skipping reinitialization since forceReinitialize is false.',
-        );
-        return instance;
-      }
-    }
-
-    // If any existing instances; ensure they are not polling
-    instance.stopPolling();
-    // Set up assignment logger and cache
-    instance.setAssignmentLogger(config.assignmentLogger);
-    if (config.banditLogger) {
-      instance.setBanditLogger(config.banditLogger);
-    }
-    // Default to obfuscated mode when requesting configuration from the server.
-    instance.setIsObfuscated(true);
-
-    const storageKeySuffix = buildStorageKeySuffix(apiKey);
-
-    // Set the configuration store to the desired persistent store, if provided.
-    // Otherwise, the factory method will detect the current environment and instantiate the correct store.
-    const configurationStore = configurationStorageFactory(
-      {
-        maxAgeSeconds: maxCacheAgeSeconds,
-        servingStoreUpdateStrategy: updateOnFetch,
-        persistentStore,
-        hasChromeStorage: hasChromeStorage(),
-        hasWindowLocalStorage: hasWindowLocalStorage(),
-      },
-      {
-        chromeStorage: chromeStorageIfAvailable(),
-        windowLocalStorage: localStorageIfAvailable(),
-        storageKeySuffix,
-      },
-    );
-    instance.setFlagConfigurationStore(configurationStore);
-
-    // instantiate and init assignment cache
-    const assignmentCache = assignmentCacheFactory({
-      chromeStorage: chromeStorageIfAvailable(),
-      storageKeySuffix,
-    });
-    if (assignmentCache instanceof HybridAssignmentCache) {
-      await assignmentCache.init();
-    }
-    instance.useCustomAssignmentCache(assignmentCache);
-
-    // Set up parameters for requesting updated configurations
-    const requestConfiguration: FlagConfigurationRequestParameters = {
-      apiKey,
-      sdkName,
-      sdkVersion,
-      baseUrl,
-      requestTimeoutMs,
-      numInitialRequestRetries,
-      numPollRequestRetries,
-      pollAfterSuccessfulInitialization,
-      pollAfterFailedInitialization,
-      pollingIntervalMs,
-      throwOnFailedInitialization: true, // always use true here as underlying instance fetch is surrounded by try/catch
-      skipInitialPoll: skipInitialRequest,
-    };
-    instance.setConfigurationRequestParameters(requestConfiguration);
-    instance.setEventDispatcher(newEventDispatcher(apiKey, eventIngestionConfig));
-
-    // We have two at-bats for initialization: from the configuration store and from fetching
-    // We can resolve the initialization promise as soon as either one succeeds
-    // If there is no persistent store underlying the ConfigurationStore, then there is no race to begin with, as
-    // there is not an async local load to wait for.
-
-    // The definition of a successful configuration load differs for a cached config vs a fetched config.
-    // Specifically, a cached config with no entries is not considered a completed load and will result in
-    // `ConfigLoaderStatus.DID_NOT_PRODUCE` while and empty config from the fetch is considered a valid, `COMPLETED`
-    //  configuration load.
-    let initFromConfigStoreError = undefined;
-    let initFromFetchError = undefined;
-
-    const attemptInitFromConfigStore: ConfigurationLoadAttempt = configurationStore
-      .init()
-      .then(async () => {
-        if (!configurationStore.getKeys().length) {
-          // Consider empty configuration stores invalid
-          applicationLogger.warn('Eppo SDK cached configuration is empty');
-          initFromConfigStoreError = new Error('Configuration store was empty');
-          return ConfigLoaderStatus.DID_NOT_PRODUCE;
-        }
-
-        const cacheIsExpired = await configurationStore.isExpired();
-        if (cacheIsExpired && !config.useExpiredCache) {
-          applicationLogger.warn('Eppo SDK set not to use expired cached configuration');
-          initFromConfigStoreError = new Error('Configuration store was expired');
-          return ConfigLoaderStatus.DID_NOT_PRODUCE;
-        } else if (cacheIsExpired && config.useExpiredCache) {
-          applicationLogger.warn('Eppo SDK config.useExpiredCache is true; using expired cache');
-        }
-
-        return ConfigLoaderStatus.COMPLETED;
-      })
-      .catch((e) => {
-        applicationLogger.warn(
-          'Eppo SDK encountered an error initializing from the configuration store',
-          e,
-        );
-        initFromConfigStoreError = e;
-        return ConfigLoaderStatus.FAILED;
-      })
-      .then((status) => {
-        return { source: ConfigSource.CONFIG_STORE, result: status };
-      });
-
-    // Kick off a remote fetch (and start the poller, if configured to do so).
-    // Before a network fetch is attempted, the `ConfiguratonRequestor` instance will check to see whether the
-    // locally-stored config data is expired. If it is not expired, the network fetch is skipped, and the promise chain
-    // will quickly return. **When data not successfully fetched due to an error, invalid data, or giving up the fetch
-    // because the cache is not expired, the configuration store will not be set as initialized.**
-    const attemptInitFromFetch: ConfigurationLoadAttempt = instance
-      .fetchFlagConfigurations()
-      .then(() => {
-        if (configurationStore.isInitialized()) {
-          // If fetch has won the race and the configStore is initialized, that means we have a successful load and the
-          // fetched data was used to init.
-          return ConfigLoaderStatus.COMPLETED;
-        } else {
-          // If the config store is not initialized and the fetch says it is done, that means the fetch did not set any
-          // values into the config store (ex:the cache is not expired or invalid config data was received).
-          // It's important not to set an error here as this state does not mean that an error was encountered.
-          // If the initial cache had not expired, the fetch would be skipped and the config store would report as
-          // uninitialized because only a successful fetch setting the data entries will set the persistent store as
-          // initialized.
-          return ConfigLoaderStatus.DID_NOT_PRODUCE;
-        }
-      })
-      .catch((e) => {
-        applicationLogger.warn('Eppo SDK encountered an error initializing from fetching', e);
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        initFromFetchError = e;
-        return ConfigLoaderStatus.FAILED;
-      })
-      .then((status) => {
-        return { source: ConfigSource.FETCH, result: status };
-      });
-
-    const racers: ConfigurationLoadAttempt[] = [attemptInitFromConfigStore];
-
-    // attemptInitFromFetch will return early and not attempt to fetch if `skipInitialRequest` is `true`.
-    // We could still race it against a load from configuration as the handling logic will see that no config was loaded
-    // into the config store from the remote fetch and return `DID_NOT_PRODUCE`.
-    if (!config.skipInitialRequest) {
-      racers.push(attemptInitFromFetch);
-    }
-    let initializationSource: ConfigSource;
-    const { source: firstSource, result: firstConfigResult } = await Promise.race(racers);
-
-    if (firstConfigResult === ConfigLoaderStatus.COMPLETED) {
-      // First config load successfully produced a configuration
-      initializationSource = firstSource;
-    } else {
-      // First attempt failed or did not produce configuration, but we have a second at bat that will be executed in the scope of the top-level try-catch
-
-      const secondAttempt =
-        firstSource === ConfigSource.FETCH ? attemptInitFromConfigStore : attemptInitFromFetch;
-
-      initializationSource = await secondAttempt.then((resultPair: ConfigLoadResult) => {
-        const { source, result } = resultPair;
-        return result === ConfigLoaderStatus.COMPLETED ? source : ConfigSource.NONE;
-      });
-    }
-
-    if (initializationSource === ConfigSource.NONE) {
-      // Neither config loader produced useful config. Return error, if exists, in order from first to last: fetch, config store, generic.
-      initializationError = initFromFetchError
-        ? initFromFetchError
-        : initFromConfigStoreError
-          ? initFromConfigStoreError
-          : new Error('Eppo SDK: No configuration source produced a valid configuration');
-    }
-    applicationLogger.debug('Initialization source', initializationSource);
-  } catch (error: unknown) {
-    initializationError = error instanceof Error ? error : new Error(String(error));
-  }
-
-  if (initializationError) {
-    applicationLogger.warn(
-      'Eppo SDK was unable to initialize with a configuration, assignment calls will return the default value and not be logged' +
-        (config.pollAfterFailedInitialization
-          ? ' until an experiment configuration is successfully retrieved'
-          : ''),
-    );
-    if (config.throwOnFailedInitialization ?? true) {
-      throw initializationError;
-    }
-  }
-
+  // For backwards compatibility.
   EppoJSClient.initialized = true;
-  return instance;
+  return client;
 }
 
 /**
@@ -597,7 +616,7 @@ async function explicitInit(config: IClientConfig): Promise<EppoClient> {
  * @returns a singleton client instance
  * @public
  */
-export function getInstance(): EppoClient {
+export function getInstance(): EppoJSClient {
   return EppoJSClient.instance;
 }
 


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
_Eppo Internal_
🎟️ towards FF-3888
📜 [Multiple Eppo Clients](https://www.notion.so/eppo/Multiple-concurrent-and-isolated-EppoClient-instances-running-within-an-application-18449cc0114380288eb3eaac580c4e53)
[Configuration Side-loading](https://www.notion.so/eppo/Configuration-side-loading-design-12249cc0114380bc9650d8dc4e189e77)

## Motivation and Context

**This PR is carved from #166 in an attempt to make #166 focused on the the "new" API.** This PR adds no net new functionality, however, the new `EppoJSClient.init` method, marked **@internal** does allow for unbuffered initialization calls just as the global `init` method previously allowed. This internal method can be made private once we remove the global `init` method in the next major release.

The `init` and `getInstance()` methods work on a singleton instance of the `EppoJSClient` which makes for a generally smooth developer experience given that the Eppo SDK essentially handles dependency management for the dev. This does have its own drawbacks, but those are not particularly relevant here.

There are use cases, however, when a non-singleton instance of the `EppoJSClient` is required. One such use case is embedding the Eppo SDK into a library which itself can be included in other applications. If that 3p library shipped with Eppo is integrated into another application that has the Eppo SDK running, there would be undefined behaviour as the SDK cannot handle this use case.

**TL;DR: We want to move away from singleton access and allow for multiple instance of the EppoJSClient while maintaining the current API**

## Description
- Move bulk of initialization to a class method
- funnel all references to the static `instance` through `getInstance()`
- deprecate `EppoJSClient.instance`
- make `initialized` and `ensureInitialized` class members; still set `EppoJSClient.initialized` as before to ensure backward compatibility with the current API

## How has this been documented?
- doc comments

## How has this been tested?
- tests