### PR TITLE
chore: update to latest common.

### DIFF
--- a/docs/js-client-sdk.eppojsclient.instance.md
+++ b/docs/js-client-sdk.eppojsclient.instance.md
@@ -4,7 +4,10 @@
 
 ## EppoJSClient.instance property
 
-@<!-- -->deprecated. use `getInstance()` instead.
+> Warning: This API is now obsolete.
+> 
+> use `getInstance()` instead.
+> 
 
 **Signature:**
 

--- a/docs/js-client-sdk.eppojsclient.md
+++ b/docs/js-client-sdk.eppojsclient.md
@@ -72,8 +72,6 @@ boolean
 
 </td><td>
 
-@<!-- -->deprecated. use `getInstance()` instead.
-
 
 </td></tr>
 </tbody></table>

--- a/js-client-sdk.api.md
+++ b/js-client-sdk.api.md
@@ -88,6 +88,7 @@ export class EppoJSClient extends EppoClient {
     init(config: Omit<IClientConfig, 'forceReinitialize'>): Promise<EppoJSClient>;
     // (undocumented)
     static initialized: boolean;
+    // @deprecated (undocumented)
     static instance: EppoJSClient;
     // @internal (undocumented)
     offlineInit(config: IClientConfigSync): void;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [
@@ -60,7 +60,7 @@
     "webpack-cli": "^6.0.1"
   },
   "dependencies": {
-    "@eppo/js-client-sdk-common": "4.10.0"
+    "@eppo/js-client-sdk-common": "4.12.0"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -10,6 +10,7 @@ import {
   constants,
   EppoClient,
   Flag,
+  FormatEnum,
   HybridConfigurationStore,
   IAsyncStore,
   IPrecomputedConfigurationResponse,
@@ -184,7 +185,7 @@ describe('EppoJSClient E2E test', () => {
 
   beforeAll(async () => {
     global.fetch = jest.fn(() => {
-      const ufc = readMockUfcResponse(MOCK_UFC_RESPONSE_FILE);
+      const ufc = readMockUfcResponse(OBFUSCATED_MOCK_UFC_RESPONSE_FILE);
 
       return Promise.resolve({
         ok: true,
@@ -416,6 +417,7 @@ describe('initialization options', () => {
 
   const maxRetryDelay = DEFAULT_POLL_INTERVAL_MS * POLL_JITTER_PCT;
   const mockConfigResponse = {
+    format: FormatEnum.CLIENT,
     flags: {
       [obfuscatedFlagKey]: mockObfuscatedUfcFlagConfig,
     },
@@ -1015,6 +1017,7 @@ describe('initialization options', () => {
               status: 200,
               json: () =>
                 Promise.resolve({
+                  format: 'CLIENT',
                   flags: {
                     [md5Hash(flagKey)]: mockObfuscatedUfcFlagConfig,
                   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5330,9 +5330,9 @@ url-parse@^1.5.3:
     requires-port "^1.0.0"
 
 uuid@^11.0.5:
-  version "11.0.5"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.5.tgz#07b46bdfa6310c92c3fb3953a8720f170427fc62"
-  integrity sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
+  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,10 +380,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz#f13c7c205915eb91ae54c557f5e92bddd8be0e83"
   integrity sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==
 
-"@eppo/js-client-sdk-common@4.10.0":
-  version "4.10.0"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.10.0.tgz#56250e42059a45545f1023ad4d47340aa892742f"
-  integrity sha512-VLChPiZl4GEoyx+7b5TqFdnMRXM/s/nvlPsOiPoSNBFH5VbNFQsc543qDYnRM/cVPVAGfmHNEKTmec2ohXwD0Q==
+"@eppo/js-client-sdk-common@4.12.0":
+  version "4.12.0"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.12.0.tgz#87836c5cbfbf49beecc832edb12a4da329e4b9ea"
+  integrity sha512-d16xB5prgH1H+OHaFZWXjVgOjyNu90JEH4SWoCxYLjypUQC0mkAw7riLFBDJ0jqQ1L9/EG0SJooXOOQ7tSjBqw==
   dependencies:
     buffer "npm:@eppo/buffer@6.2.0"
     js-base64 "^3.7.7"


### PR DESCRIPTION
## Motivation and Context
A recent change to the common package moved the source-of-truth of obfuscation to config store metadata (via format). The EppoJS client and its tests require updating to ensure the format metadata is being used instead of the deprecated internal isObfuscated field. 

## Description
- update to latest common
- minor bump to `3.12.0`
- set default format metadata where needed
- update tests to use an obfuscated config file (common package caches whether config is obfuscated)
- docs

## How has this been tested?
- no functional changes
