### PR TITLE
chore: Prepare for v3.13.0 releaes

### DIFF
--- a/js-client-sdk.api.md
+++ b/js-client-sdk.api.md
@@ -14,6 +14,7 @@ import { BanditSubjectAttributes } from '@eppo/js-client-sdk-common';
 import { ContextAttributes } from '@eppo/js-client-sdk-common';
 import { EppoClient } from '@eppo/js-client-sdk-common';
 import { EppoPrecomputedClient } from '@eppo/js-client-sdk-common';
+import { EventDispatcher } from '@eppo/js-client-sdk-common';
 import { Flag } from '@eppo/js-client-sdk-common';
 import { FlagKey } from '@eppo/js-client-sdk-common';
 import { IAssignmentDetails } from '@eppo/js-client-sdk-common';
@@ -143,12 +144,13 @@ export { IBanditLogger }
 export interface IClientConfig extends IBaseRequestConfig {
     enableOverrides?: boolean;
     eventIngestionConfig?: {
-        deliveryIntervalMs?: number;
-        retryIntervalMs?: number;
-        maxRetryDelayMs?: number;
-        maxRetries?: number;
         batchSize?: number;
+        deliveryIntervalMs?: number;
+        disabled?: boolean;
         maxQueueSize?: number;
+        maxRetries?: number;
+        maxRetryDelayMs?: number;
+        retryIntervalMs?: number;
     };
     forceReinitialize?: boolean;
     maxCacheAgeSeconds?: number;
@@ -206,6 +208,9 @@ export interface IPrecomputedClientConfigSync {
     // (undocumented)
     throwOnFailedInitialization?: boolean;
 }
+
+// @public (undocumented)
+export const NO_OP_EVENT_DISPATCHER: EventDispatcher;
 
 export { ObfuscatedFlag }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [
@@ -60,7 +60,7 @@
     "webpack-cli": "^6.0.1"
   },
   "dependencies": {
-    "@eppo/js-client-sdk-common": "4.12.0"
+    "@eppo/js-client-sdk-common": "4.13.0"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,6 +78,7 @@ export {
   IAsyncStore,
   Flag,
   ObfuscatedFlag,
+  EppoAssignmentLogger,
 
   // Bandits
   IBanditLogger,

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,10 +380,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz#f13c7c205915eb91ae54c557f5e92bddd8be0e83"
   integrity sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==
 
-"@eppo/js-client-sdk-common@4.12.0":
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.12.0.tgz#87836c5cbfbf49beecc832edb12a4da329e4b9ea"
-  integrity sha512-d16xB5prgH1H+OHaFZWXjVgOjyNu90JEH4SWoCxYLjypUQC0mkAw7riLFBDJ0jqQ1L9/EG0SJooXOOQ7tSjBqw==
+"@eppo/js-client-sdk-common@4.13.0":
+  version "4.13.0"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.13.0.tgz#67d57a905bd292bd616ce0d4c200e8b36b5914d4"
+  integrity sha512-i9g3lY8Dz1LRse8fbyC9MwFeufHLhiWaVZQsOKWVHn5mP/z+2UGgUDvT0CigKp8xVjsQNTqlBXaF6+WG71VoIA==
   dependencies:
     buffer "npm:@eppo/buffer@6.2.0"
     js-base64 "^3.7.7"


### PR DESCRIPTION
## Motivation and Context
* Bump js-common-sdk to v4.13.0
* Export new API `EppoAssignmentLogger`
* Bring it on par with its counterpart https://github.com/Eppo-exp/node-server-sdk/pull/97 in node-server-sdk