### PR TITLE
chore: Upgrade to js-client-sdk-common@4.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "3.15.0-prerelease.1",
+  "version": "3.15.0",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "webpack-cli": "^6.0.1"
   },
   "dependencies": {
-    "@eppo/js-client-sdk-common": "4.14.4"
+    "@eppo/js-client-sdk-common": "/tmp/packages/js-client-sdk-common"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "3.14.1",
+  "version": "3.15.0-prerelease.1",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "webpack-cli": "^6.0.1"
   },
   "dependencies": {
-    "@eppo/js-client-sdk-common": "/tmp/packages/js-client-sdk-common"
+    "@eppo/js-client-sdk-common": "4.15.1"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -32,6 +32,7 @@ import {
 
 import { IClientConfig } from './i-client-config';
 import { ServingStoreUpdateStrategy } from './isolatable-hybrid.store';
+import { sdkVersion } from './sdk-data';
 
 import {
   EppoPrecomputedJSClient,
@@ -47,6 +48,8 @@ import {
 } from './index';
 
 const { DEFAULT_POLL_INTERVAL_MS, POLL_JITTER_PCT } = constants;
+
+const expectedSdkParams = `&sdkName=js-client-sdk&sdkVersion=${sdkVersion}`;
 
 function md5Hash(input: string): string {
   return createHash('md5').update(input).digest('hex');
@@ -643,6 +646,7 @@ describe('initialization options', () => {
 
   describe('enhanced SDK token', () => {
     let urlsRequested: string[] = [];
+
     afterEach(() => {
       urlsRequested = [];
     });
@@ -664,11 +668,10 @@ describe('initialization options', () => {
         assignmentLogger: mockLogger,
       });
       expect(urlsRequested).toHaveLength(1);
-      expect(
-        urlsRequested[0].startsWith(
-          'https://experiment.fscdn.eppo.cloud/api/flag-config/v1/config?apiKey=zCsQuoHJxVPp895.Y3M9ZXhwZXJpbWVudA%3D%3D',
-        ),
-      ).toBeTruthy();
+      expect(urlsRequested[0]).toEqual(
+        'https://experiment.fscdn.eppo.cloud/api/flag-config/v1/config?apiKey=zCsQuoHJxVPp895.Y3M9ZXhwZXJpbWVudA%3D%3D' +
+          expectedSdkParams,
+      );
     });
 
     it('uses the provided custom relative baseUrl', async () => {
@@ -679,11 +682,10 @@ describe('initialization options', () => {
       });
 
       expect(urlsRequested).toHaveLength(1);
-      expect(
-        urlsRequested[0].startsWith(
-          '//custom-base-url.com/flag-config/v1/config?apiKey=zCsQuoHJxVPp895.Y3M9ZXhwZXJpbWVudA%3D%3D',
-        ),
-      ).toBeTruthy();
+      expect(urlsRequested[0]).toEqual(
+        '//custom-base-url.com/flag-config/v1/config?apiKey=zCsQuoHJxVPp895.Y3M9ZXhwZXJpbWVudA%3D%3D' +
+          expectedSdkParams,
+      );
     });
 
     it('uses the provided custom baseUrl and prepends https', async () => {
@@ -694,11 +696,10 @@ describe('initialization options', () => {
       });
 
       expect(urlsRequested).toHaveLength(1);
-      expect(
-        urlsRequested[0].startsWith(
-          'https://custom-base-url.com/flag-config/v1/config?apiKey=zCsQuoHJxVPp895.Y3M9ZXhwZXJpbWVudA%3D%3D',
-        ),
-      ).toBeTruthy();
+      expect(urlsRequested[0]).toEqual(
+        'https://custom-base-url.com/flag-config/v1/config?apiKey=zCsQuoHJxVPp895.Y3M9ZXhwZXJpbWVudA%3D%3D' +
+          expectedSdkParams,
+      );
     });
 
     it('falls back to the default url', async () => {
@@ -708,11 +709,10 @@ describe('initialization options', () => {
       });
 
       expect(urlsRequested).toHaveLength(1);
-      expect(
-        urlsRequested[0].startsWith(
-          'https://fscdn.eppo.cloud/api/flag-config/v1/config?apiKey=old+style+key',
-        ),
-      ).toBeTruthy();
+      expect(urlsRequested[0]).toEqual(
+        'https://fscdn.eppo.cloud/api/flag-config/v1/config?apiKey=old+style+key' +
+          expectedSdkParams,
+      );
     });
   });
 
@@ -1415,6 +1415,7 @@ describe('EppoPrecomputedJSClient E2E test', () => {
 
   describe('with an enhanced SDK token', () => {
     let urlsRequested: string[] = [];
+
     afterEach(() => {
       urlsRequested = [];
     });
@@ -1447,8 +1448,9 @@ describe('EppoPrecomputedJSClient E2E test', () => {
       });
 
       expect(urlsRequested).toHaveLength(1);
-      expect(urlsRequested[0]).toContain(
-        'https://experiment.fs-edge-assignment.eppo.cloud/assignments?apiKey=zCsQuoHJxVPp895.Y3M9ZXhwZXJpbWVudA%3D%3D',
+      expect(urlsRequested[0]).toEqual(
+        'https://experiment.fs-edge-assignment.eppo.cloud/assignments?apiKey=zCsQuoHJxVPp895.Y3M9ZXhwZXJpbWVudA%3D%3D' +
+          expectedSdkParams,
       );
     });
 
@@ -1464,8 +1466,9 @@ describe('EppoPrecomputedJSClient E2E test', () => {
       });
 
       expect(urlsRequested).toHaveLength(1);
-      expect(urlsRequested[0]).toContain(
-        '//custom-base-url.com/assignments?apiKey=zCsQuoHJxVPp895.Y3M9ZXhwZXJpbWVudA%3D%3D',
+      expect(urlsRequested[0]).toEqual(
+        '//custom-base-url.com/assignments?apiKey=zCsQuoHJxVPp895.Y3M9ZXhwZXJpbWVudA%3D%3D' +
+          expectedSdkParams,
       );
     });
 
@@ -1481,8 +1484,9 @@ describe('EppoPrecomputedJSClient E2E test', () => {
       });
 
       expect(urlsRequested).toHaveLength(1);
-      expect(urlsRequested[0]).toContain(
-        '//custom-base-url.com/assignments?apiKey=zCsQuoHJxVPp895.Y3M9ZXhwZXJpbWVudA%3D%3D',
+      expect(urlsRequested[0]).toEqual(
+        '//custom-base-url.com/assignments?apiKey=zCsQuoHJxVPp895.Y3M9ZXhwZXJpbWVudA%3D%3D' +
+          expectedSdkParams,
       );
     });
 
@@ -1497,8 +1501,9 @@ describe('EppoPrecomputedJSClient E2E test', () => {
       });
 
       expect(urlsRequested).toHaveLength(1);
-      expect(urlsRequested[0]).toContain(
-        'https://fs-edge-assignment.eppo.cloud/assignments?apiKey=Y3M9ZXhwZXJpbWVudA%3D%3D',
+      expect(urlsRequested[0]).toEqual(
+        'https://fs-edge-assignment.eppo.cloud/assignments?apiKey=Y3M9ZXhwZXJpbWVudA%3D%3D' +
+          expectedSdkParams,
       );
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,6 +100,9 @@ const flagConfigurationStore = configurationStorageFactory({
 const memoryOnlyPrecomputedFlagsStore = precomputedFlagsStorageFactory();
 const memoryOnlyPrecomputedBanditsStore = precomputedBanditStoreFactory();
 
+/**
+ * @internal
+ */
 export const NO_OP_EVENT_DISPATCHER: EventDispatcher = {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   attachContext: () => {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,8 +380,10 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz#f13c7c205915eb91ae54c557f5e92bddd8be0e83"
   integrity sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==
 
-"@eppo/js-client-sdk-common@/tmp/packages/js-client-sdk-common":
+"@eppo/js-client-sdk-common@4.15.1":
   version "4.15.1"
+  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.15.1.tgz#bf2d602b1462eb156224edd73f734a3c99267816"
+  integrity sha512-ZVyczDCfAMAnuUlfE293b6h2wfDOcZnfxXHS52r0OU9GktdTYD9EuC3Arpzw4JeTgzV1vW6iTzoz5HDJHwZz6A==
   dependencies:
     buffer "npm:@eppo/buffer@6.2.0"
     js-base64 "^3.7.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,10 +380,8 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz#f13c7c205915eb91ae54c557f5e92bddd8be0e83"
   integrity sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==
 
-"@eppo/js-client-sdk-common@4.14.4":
-  version "4.14.4"
-  resolved "https://registry.yarnpkg.com/@eppo/js-client-sdk-common/-/js-client-sdk-common-4.14.4.tgz#fd59daa3b9ae385756476bcc1022a53ffcfd8188"
-  integrity sha512-12JKsYLu+WICH1t9NEgWoxTYc/MyFnZAHhcBJwfcaG0tPIbPfgG9VBT8yTUgBLG8cYZBmDVk7R7SzMGc3vD2eg==
+"@eppo/js-client-sdk-common@/tmp/packages/js-client-sdk-common":
+  version "4.15.0"
   dependencies:
     buffer "npm:@eppo/buffer@6.2.0"
     js-base64 "^3.7.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -381,7 +381,7 @@
   integrity sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==
 
 "@eppo/js-client-sdk-common@/tmp/packages/js-client-sdk-common":
-  version "4.15.0"
+  version "4.15.1"
   dependencies:
     buffer "npm:@eppo/buffer@6.2.0"
     js-base64 "^3.7.7"


### PR DESCRIPTION
- Upgrades to js-common@4.15.1 see _[release notes](https://github.com/Eppo-exp/js-sdk-common/releases/tag/v4.15.1)_
- adds tests to verify CDN target.