### PR TITLE
Ability to specify configuration dates with offline init

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "3.15.1",
+  "version": "3.16.0",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -418,21 +418,22 @@ describe('sync init', () => {
   });
 
   it('sets configuration dates', () => {
-    const testStart = Date.now();
+    const testStart = new Date();
+    const configPublishedAt = new Date(testStart.getTime() - 10000).toISOString();
+    const configFetchedAt = testStart.toISOString();
     const client = offlineInit({
       flagsConfiguration: {
         [flagKey]: mockNotObfuscatedFlagConfig,
       },
-      //TODO: set dates
+      configPublishedAt,
+      configFetchedAt,
     });
 
     const result = client.getStringAssignmentDetails(flagKey, 'subject-10', {}, 'default-value');
 
     expect(result.variation).toBe('variant-1');
-    expect(result.evaluationDetails.configPublishedAt).toBeTruthy();
-    expect(new Date(result.evaluationDetails.configFetchedAt).getTime()).toBeGreaterThanOrEqual(
-      testStart,
-    );
+    expect(result.evaluationDetails.configPublishedAt).toBe(configPublishedAt);
+    expect(result.evaluationDetails.configFetchedAt).toBe(configFetchedAt);
   });
 });
 

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -416,6 +416,24 @@ describe('sync init', () => {
       'variant-1',
     );
   });
+
+  it('sets configuration dates', () => {
+    const testStart = Date.now();
+    const client = offlineInit({
+      flagsConfiguration: {
+        [flagKey]: mockNotObfuscatedFlagConfig,
+      },
+      //TODO: set dates
+    });
+
+    const result = client.getStringAssignmentDetails(flagKey, 'subject-10', {}, 'default-value');
+
+    expect(result.variation).toBe('variant-1');
+    expect(result.evaluationDetails.configPublishedAt).toBeTruthy();
+    expect(new Date(result.evaluationDetails.configFetchedAt).getTime()).toBeGreaterThanOrEqual(
+      testStart,
+    );
+  });
 });
 
 describe('initialization options', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,10 @@ export interface IClientConfigSync {
   enableOverrides?: boolean;
 
   overridesStorageKey?: string;
+
+  configPublishedAt?: string; // ISO Datetime String
+
+  configFetchedAt?: string; // ISO Datetime String
 }
 
 export { IClientConfig, IPrecomputedClientConfig };
@@ -543,6 +547,13 @@ export class EppoJSClient extends EppoClient {
           applicationLogger.warn('Error setting flags for memory-only configuration store', err),
         );
       this.setFlagConfigurationStore(memoryOnlyConfigurationStore);
+
+      if (config.configPublishedAt) {
+        memoryOnlyConfigurationStore.setConfigPublishedAt(config.configPublishedAt);
+      }
+      if (config.configFetchedAt) {
+        memoryOnlyConfigurationStore.setConfigFetchedAt(config.configFetchedAt);
+      }
 
       if (enableOverrides) {
         const overrideStore = overrideStorageFactory(


### PR DESCRIPTION
---
labels: mergeable
---
_Eppo Internal_
[//]: #  (Link to the issue or doc corresponding to this chunk of work)
🎟️ Fixes: [FF-4344 - Ensure JS Client offline init sets config published and fetched at](https://linear.app/eppo/issue/FF-4344/ensure-js-client-offline-init-sets-config-published-and-fetched-at)
👯 **Related PR:** [`eppo #12880`](https://github.com/Eppo-exp/eppo/pull/12880)

## Motivation and Context
Evaluation details include the dates the configuration was published and fetched. However, when offline initialized, these need to be provided.

## Description
Add the publish and fetch dates for the configuration as optional parameters for the synchronous client configuration, and then set them to the underlying offline init memory store

## How has this been documented?
not needed; bugfix

## How has this been tested?
* Added a test case to `index.spec.ts`
  ![image](https://github.com/user-attachments/assets/6f97bc27-9387-4c3e-934a-4c55aac931a1)
* Installed this branch in local eppo environment; used the functionality to pass dates
  ![image](https://github.com/user-attachments/assets/3d7ac594-dec4-4235-b93e-7b3bd33e5705)
