### PR TITLE
Use right class for static initialization check

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eppo/js-client-sdk",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "description": "Eppo SDK for client-side JavaScript applications",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -750,7 +750,7 @@ export class EppoPrecomputedJSClient extends EppoPrecomputedClient {
   }
 
   private static getAssignmentInitializationCheck() {
-    if (!EppoJSClient.initialized) {
+    if (!EppoPrecomputedJSClient.initialized) {
       applicationLogger.warn('Eppo SDK assignment requested before init() completed');
     }
   }


### PR DESCRIPTION
---
labels: mergeable
---
_Eppo Internal_
[//]: #  (Link to the issue or doc corresponding to this chunk of work)
🎟️ Fixes: [FF-4383 - JS Precomputed client warns not initialized despite being initialized](https://linear.app/eppo/issue/FF-4383/js-precomputed-client-warns-not-initialized-despite-being-initialized)

## Motivation and Context
Our precomputed client warns that it's not initialized when it is, which can cause confusion.

## Description
The reason is that it was checking the wrong static class for the initialized boolean

## How has this been tested?
Used `eppo-precomputed-client.spec.ts`. Saw the warning, made the fix, no more warning.
![image](https://github.com/user-attachments/assets/41fb40b5-99fb-4f83-931f-892bf043389c)