### PR TITLE
fix(FFESUPPORT-884): re-resolve brace-expansion to patched versions (Vanta 2026-07)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1781,9 +1781,9 @@ baseline-browser-mapping@^2.10.12:
   integrity sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==
 
 brace-expansion@^1.1.7:
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.14.tgz#d9de602370d91347cd9ddad1224d4fd701eb348b"
-  integrity sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==
+  version "1.1.16"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
+  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -1796,9 +1796,9 @@ brace-expansion@^2.0.2:
     balanced-match "^1.0.0"
 
 brace-expansion@^5.0.2, brace-expansion@^5.0.5:
-  version "5.0.5"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.5.tgz#dcc3a37116b79f3e1b46db994ced5d570e930fdb"
-  integrity sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.7.tgz#1b0e46965b479dad65af737b4a02790a05498337"
+  integrity sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==
   dependencies:
     balanced-match "^4.0.2"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1789,9 +1789,9 @@ brace-expansion@^1.1.7:
     concat-map "0.0.1"
 
 brace-expansion@^2.0.2:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.0.tgz#4f41a41190216ee36067ec381526fe9539c4f0ae"
-  integrity sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.2.tgz#0bba2271feb7d458b0d31ad13625aaa4754431e2"
+  integrity sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==
   dependencies:
     balanced-match "^1.0.0"
 


### PR DESCRIPTION
🤖 **Generated from Claude**

Resolves the July 2026 Vanta/Dependabot supplement for **js-client-sdk** — [FFESUPPORT-884](https://datadoghq.atlassian.net/browse/FFESUPPORT-884).

## What & why
One open advisory remained after the prior July sweep (#285): **brace-expansion** GHSA-3jxr-9vmj-r5cp / CVE-2026-13149 (ReDoS), which affects `>= 3.0.0, < 5.0.7` and `< 1.1.16`. It is a **transitive, dev-only** dependency (build/test tooling — no runtime, nothing in the published bundle).

Fix is a **lockfile re-resolution only** — no `package.json` or `resolutions` change:

| Package | Before | After |
| --- | --- | --- |
| brace-expansion (1.x line) | 1.1.14 | 1.1.16 |
| brace-expansion (5.x line) | 5.0.5 | 5.0.7 |

(The `^2.0.2` line was also bumped 2.1.0 → 2.1.2 to clear the advisory's `>= 2.0.0, < 2.1.2` range — a codex review caught that this third range was missed initially.)

## How tests/CI protect this change
`yarn typecheck` clean and `yarn test:unit` green locally (153/153). CI runs the full build + unit suite; because the change is transitive dev tooling only, the build + test pass is the safety net.

## Deferred / out of scope
None — this was the only open advisory for this repo.
